### PR TITLE
Avoid C_FLAGS overwrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(RUNTIME_CHECKS 0)
 #set(RUNTIME_CHECKS 0)
 
 # compiler flags
-set(CMAKE_C_FLAGS "")
+# set(CMAKE_C_FLAGS "")
 
 # optimization flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")


### PR DESCRIPTION
Line 64 is causing problems in software that use `HPIPM` as a `cmake` sub-directory.
I'm not sure which is the best way to minimize flags interference between `HPIPM` and "parent" software.