### PR TITLE
modified set dims functions to take const char * for c++ compatibility

### DIFF
--- a/dense_qp/x_dense_qp_dim.c
+++ b/dense_qp/x_dense_qp_dim.c
@@ -68,7 +68,7 @@ void CVT_INT_TO_DENSE_QP_DIM(int nv, int ne, int nb, int ng, int nsb, int nsg, s
 	}
 
 
-void SET_DENSE_QP_DIM(char *field_name, int value, struct DENSE_QP_DIM *dim)
+void SET_DENSE_QP_DIM(const char *field_name, int value, struct DENSE_QP_DIM *dim)
 	{
 	if(hpipm_strcmp(field_name, "nv"))
 		{ 

--- a/include/hpipm_d_dense_qp_dim.h
+++ b/include/hpipm_d_dense_qp_dim.h
@@ -59,7 +59,7 @@ void d_create_dense_qp_dim(struct d_dense_qp_dim *qp_dim, void *memory);
 //
 void d_cvt_int_to_dense_qp_dim(int nv, int ne, int nb, int ng, int nsb, int nsg, struct d_dense_qp_dim *dim);
 //
-void d_set_dense_qp_dim(char *field_name, int value, struct d_dense_qp_dim *dim);
+void d_set_dense_qp_dim(const char *field_name, int value, struct d_dense_qp_dim *dim);
 
 
 

--- a/include/hpipm_d_ocp_qp_dim.h
+++ b/include/hpipm_d_ocp_qp_dim.h
@@ -65,7 +65,7 @@ void d_create_ocp_qp_dim(int N, struct d_ocp_qp_dim *qp_dim, void *memory);
 //
 void d_cvt_int_to_ocp_qp_dim(int N, int *nx, int *nu, int *nbx, int *nbu, int *ng, int *ns, struct d_ocp_qp_dim *dim);
 //
-void d_set_ocp_qp_dim(char *field, int stage, int in, struct d_ocp_qp_dim *dim);
+void d_set_ocp_qp_dim(const char *field, int stage, int in, struct d_ocp_qp_dim *dim);
 //
 void d_set_ocp_qp_dim_nx(int stage, int nx, struct d_ocp_qp_dim *dim);
 //

--- a/include/hpipm_s_dense_qp_dim.h
+++ b/include/hpipm_s_dense_qp_dim.h
@@ -59,7 +59,7 @@ void s_create_dense_qp_dim(struct s_dense_qp_dim *qp_dim, void *memory);
 //
 void s_cvt_int_to_dense_qp_dim(int nv, int ne, int nb, int ng, int nsb, int nsg, struct s_dense_qp_dim *dim);
 //
-void s_set_dense_qp_dim(char *field_name, int value, struct s_dense_qp_dim *dim);
+void s_set_dense_qp_dim(const char *field_name, int value, struct s_dense_qp_dim *dim);
 
 
 

--- a/include/hpipm_s_ocp_qp_dim.h
+++ b/include/hpipm_s_ocp_qp_dim.h
@@ -65,7 +65,7 @@ void s_create_ocp_qp_dim(int N, struct s_ocp_qp_dim *qp_dim, void *memory);
 //
 void s_cvt_int_to_ocp_qp_dim(int N, int *nx, int *nu, int *nbx, int *nbu, int *ng, int *ns, struct s_ocp_qp_dim *dim);
 //
-void s_set_ocp_qp_dim(char *field, int stage, int in, struct s_ocp_qp_dim *dim);
+void s_set_ocp_qp_dim(const char *field, int stage, int in, struct s_ocp_qp_dim *dim);
 //
 void s_set_ocp_qp_dim_nx(int stage, int nx, struct s_ocp_qp_dim *dim);
 //

--- a/ocp_qp/x_ocp_qp_dim.c
+++ b/ocp_qp/x_ocp_qp_dim.c
@@ -157,7 +157,7 @@ void CVT_INT_TO_OCP_QP_DIM(int N, int *nx, int *nu, int *nbx, int *nbu, int *ng,
 
 
 
-void SET_OCP_QP_DIM(char *field_name, int stage, int value, struct OCP_QP_DIM *dim)
+void SET_OCP_QP_DIM(const char *field_name, int stage, int value, struct OCP_QP_DIM *dim)
 	{
 	if(hpipm_strcmp(field_name, "nx"))
 		{ 


### PR DESCRIPTION
Without the `const`, c++ will warn you, if you want to use something like:
`ocp_nlp_dims_set_cost(config, dims, "ny", ny);`