### PR TITLE
Generate lists of allowed targets and pass to parent CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,17 @@ set(REF_BLAS 0 CACHE STRING "Set CPU architecture target")
 # set(REF_BLAS BLIS     CACHE STRING "Set CPU architecture target")
 # set(REF_BLAS ATLAS    CACHE STRING "Set CPU architecture target")
 
+# Populate a list of allowable BLAS versions and link it to the option
+set(ALLOWED_REF_BLAS
+		0
+		OPENBLAS
+		NETLIB
+		MKL
+		BLIS
+		ATLAS
+		)
+set_property(CACHE REF_BLAS PROPERTY STRINGS ${ALLOWED_REF_BLAS})
+
 # set(HPIPM_TESTING ON CACHE BOOL "Tests enabled")
 set(HPIPM_TESTING OFF CACHE BOOL "Tests disabled")
 
@@ -50,8 +61,22 @@ set(HPIPM_TESTING OFF CACHE BOOL "Tests disabled")
 set(TARGET AVX CACHE STRING "Set CPU architecture target")
 #set(TARGET GENERIC CACHE STRING "Set CPU architecture target")
 
+# Populate a list of allowable targets and link it to the option
+set(ALLOWED_TARGETS
+		AVX
+		GENERIC
+		)
+set_property(CACHE TARGET PROPERTY STRINGS ${ALLOWED_TARGETS})
+
 # build shared library
 set(BUILD_SHARED_LIBS OFF CACHE STRING "Build shared libraries")
+
+# Pass the allowed items up to the parent scope (if there is one)
+# This is detected by comparing the project name to the one set earlier in this file
+if(NOT ${CMAKE_PROJECT_NAME} STREQUAL hpipm)
+	set(HPIPM_ALLOWED_TARGETS ${ALLOWED_TARGETS} PARENT_SCOPE)
+	set(HPIPM_ALLOWED_REF_BLAS ${ALLOWED_REF_BLAS} PARENT_SCOPE)
+endif()
 
 # Installation
 set(CMAKE_INSTALL_PREFIX "/opt/hpipm" CACHE STRING "Installation path")


### PR DESCRIPTION
Pass the valid options for target and BLAS type up to the parent CMake file (if it exists), and also allow CMake GUIs to cycle through the valid options.

This is similar to https://github.com/giaf/blasfeo/pull/100, and will be eventually used by ACADOS.