### PR TITLE
Obtain BLASFEO_PATH and BLASFEO_INCLUDE_DIR from find_package(blasfeo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ if(NOT ${CMAKE_PROJECT_NAME} STREQUAL hpipm)
 	set(HPIPM_ALLOWED_REF_BLAS ${ALLOWED_REF_BLAS} PARENT_SCOPE)
 endif()
 
+# Try to find blasfeo using CMake (also sets BLASFEO_PATH and BLASFEO_INCLUDE_DIR if found)
+find_package(blasfeo QUIET)
+
 # BLASFEO Option
 if(NOT TARGET blasfeo)
 	set(BLASFEO_PATH "/opt/blasfeo" CACHE STRING "BLASFEO installation path")


### PR DESCRIPTION
Related to: https://github.com/giaf/blasfeo/pull/129

Automatically define `BLASFEO_PATH` and `BLASFEO_INCLUDE_DIR` from `blasfeo` target if that is found. It's configured to fail silently and both variables can still be overwritten via command-line, such that the previous working mode essentially still works.