### PR TITLE
introduce configurable type for memory size calculation

### DIFF
--- a/archive/include/hpipm_d_irk_int.h
+++ b/archive/include/hpipm_d_irk_int.h
@@ -52,7 +52,7 @@ struct d_irk_workspace
 	int nx; // number of states
 	int nf; // number of forward sensitivities
 	int np; // number of parameters
-	int memsize; // TODO
+	hpipm_size_t memsize; // TODO
 	};
 
 
@@ -67,7 +67,7 @@ struct d_irk_args
 
 
 //
-int d_memsize_irk_int(struct d_rk_data *rk_data, int nx, int nf, int np);
+hpipm_size_t d_memsize_irk_int(struct d_rk_data *rk_data, int nx, int nf, int np);
 //
 void d_create_irk_int(struct d_rk_data *rk_data, int nx, int nf, int np, struct d_irk_workspace *workspace, void *memory);
 //

--- a/archive/include/hpipm_d_ocp_nlp.h
+++ b/archive/include/hpipm_d_ocp_nlp.h
@@ -65,13 +65,13 @@ struct d_ocp_nlp
 	int *ns; // number of soft constraints
 	int **idxs; // index of soft constraints
 	int N; // hotizon lenght
-	int memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_memsize_ocp_nlp(int N, int *nx, int *nu, int *nb, int *ng, int *ns);
+hpipm_size_t d_memsize_ocp_nlp(int N, int *nx, int *nu, int *nb, int *ng, int *ns);
 //
 void d_create_ocp_nlp(int N, int *nx, int *nu, int *nb, int *ng, int *ns, struct d_ocp_nlp *nlp, void *memory);
 //

--- a/archive/include/hpipm_d_ocp_nlp_hyb.h
+++ b/archive/include/hpipm_d_ocp_nlp_hyb.h
@@ -55,7 +55,7 @@ struct d_ocp_nlp_hyb_arg
 	int stat_max; // iterations saved in stat
 	int N2; // horizon of partially condensed QP
 	int pred_corr; // use Mehrotra's predictor-corrector IPM algirthm
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -76,20 +76,20 @@ struct d_ocp_nlp_hyb_workspace
 	double nlp_res_m; // exit inf norm of residuals
 	int iter_qp; // qp ipm iteration number
 	int iter_nlp; // nlp ipm iteration number
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_memsize_ocp_nlp_hyb_arg(struct d_ocp_nlp *nlp);
+hpipm_size_t d_memsize_ocp_nlp_hyb_arg(struct d_ocp_nlp *nlp);
 //
 void d_create_ocp_nlp_hyb_arg(struct d_ocp_nlp *nlp, struct d_ocp_nlp_hyb_arg *arg, void *mem);
 //
 void d_set_default_ocp_nlp_hyb_arg(struct d_ocp_nlp_hyb_arg *arg);
 
 //
-int d_memsize_ocp_nlp_hyb(struct d_ocp_nlp *nlp, struct d_ocp_nlp_hyb_arg *arg);
+hpipm_size_t d_memsize_ocp_nlp_hyb(struct d_ocp_nlp *nlp, struct d_ocp_nlp_hyb_arg *arg);
 //
 void d_create_ocp_nlp_hyb(struct d_ocp_nlp *nlp, struct d_ocp_nlp_hyb_arg *arg, struct d_ocp_nlp_hyb_workspace *ws, void *mem);
 //

--- a/archive/include/hpipm_d_ocp_nlp_ipm.h
+++ b/archive/include/hpipm_d_ocp_nlp_ipm.h
@@ -49,7 +49,7 @@ struct d_ocp_nlp_ipm_arg
 	int nlp_iter_max; // exit cond in iter number
 	int stat_max; // iterations saved in stat
 	int pred_corr; // use Mehrotra's predictor-corrector IPM algirthm
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -65,20 +65,20 @@ struct d_ocp_nlp_ipm_workspace
 	double nlp_res_d; // exit inf norm of residuals
 	double nlp_res_m; // exit inf norm of residuals
 	int iter; // iteration number
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_memsize_ocp_nlp_ipm_arg(struct d_ocp_nlp *nlp);
+hpipm_size_t d_memsize_ocp_nlp_ipm_arg(struct d_ocp_nlp *nlp);
 //
 void d_create_ocp_nlp_ipm_arg(struct d_ocp_nlp *nlp, struct d_ocp_nlp_ipm_arg *arg, void *mem);
 //
 void d_set_default_ocp_nlp_ipm_arg(struct d_ocp_nlp_ipm_arg *arg);
 
 //
-int d_memsize_ocp_nlp_ipm(struct d_ocp_nlp *nlp, struct d_ocp_nlp_ipm_arg *arg);
+hpipm_size_t d_memsize_ocp_nlp_ipm(struct d_ocp_nlp *nlp, struct d_ocp_nlp_ipm_arg *arg);
 //
 void d_create_ocp_nlp_ipm(struct d_ocp_nlp *nlp, struct d_ocp_nlp_ipm_arg *arg, struct d_ocp_nlp_ipm_workspace *ws, void *mem);
 //

--- a/archive/include/hpipm_d_ocp_nlp_sol.h
+++ b/archive/include/hpipm_d_ocp_nlp_sol.h
@@ -42,13 +42,13 @@ struct d_ocp_nlp_sol
 	struct blasfeo_dvec *pi;
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
-	int memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_memsize_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns);
+hpipm_size_t d_memsize_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns);
 //
 void d_create_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns, struct d_ocp_nlp_sol *qp_sol, void *memory);
 //

--- a/archive/include/hpipm_d_ocp_nlp_sqp.h
+++ b/archive/include/hpipm_d_ocp_nlp_sqp.h
@@ -71,20 +71,20 @@ struct d_ocp_nlp_sqp_workspace
 	double nlp_res_d; // exit inf norm of residuals
 	double nlp_res_m; // exit inf norm of residuals
 	int iter; // iteration number
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_memsize_ocp_nlp_sqp_arg(struct d_ocp_nlp *nlp);
+hpipm_size_t d_memsize_ocp_nlp_sqp_arg(struct d_ocp_nlp *nlp);
 //
 void d_create_ocp_nlp_sqp_arg(struct d_ocp_nlp *nlp, struct d_ocp_nlp_sqp_arg *arg, void *mem);
 //
 void d_set_default_ocp_nlp_sqp_arg(struct d_ocp_nlp_sqp_arg *arg);
 
 //
-int d_memsize_ocp_nlp_sqp(struct d_ocp_nlp *nlp, struct d_ocp_nlp_sqp_arg *arg);
+hpipm_size_t d_memsize_ocp_nlp_sqp(struct d_ocp_nlp *nlp, struct d_ocp_nlp_sqp_arg *arg);
 //
 void d_create_ocp_nlp_sqp(struct d_ocp_nlp *nlp, struct d_ocp_nlp_sqp_arg *arg, struct d_ocp_nlp_sqp_workspace *ws, void *mem);
 //

--- a/archive/include/hpipm_s_ocp_nlp_sol.h
+++ b/archive/include/hpipm_s_ocp_nlp_sol.h
@@ -43,13 +43,13 @@ struct s_ocp_nlp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	struct blasfeo_svec *eta0;
-	int memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_memsize_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns, int ne0);
+hpipm_size_t s_memsize_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns, int ne0);
 //
 void s_create_ocp_nlp_sol(int N, int *nx, int *nu, int *nb, int *ng, int *ns, int ne0, struct s_ocp_nlp_sol *qp_sol, void *memory);
 //

--- a/archive/ocp_nlp/d_ocp_nlp.c
+++ b/archive/ocp_nlp/d_ocp_nlp.c
@@ -61,7 +61,7 @@
 
 
 
-int MEMSIZE_OCP_NLP(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
+hpipm_size_t MEMSIZE_OCP_NLP(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
 	{
 
 	int ii;
@@ -72,7 +72,7 @@ int MEMSIZE_OCP_NLP(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
 		nuxM = nu[ii]+nx[ii]>nuxM ? nu[ii]+nx[ii] : nuxM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 5*(N+1)*sizeof(int); // nx nu nb ng ns
 	size += 2*(N+1)*sizeof(int *); // idxb idxs

--- a/archive/ocp_nlp/d_ocp_nlp_hyb.c
+++ b/archive/ocp_nlp/d_ocp_nlp_hyb.c
@@ -99,12 +99,12 @@
 
 
 
-int d_memsize_ocp_nlp_hyb_arg(struct OCP_NLP *nlp)
+hpipm_size_t d_memsize_ocp_nlp_hyb_arg(struct OCP_NLP *nlp)
 	{
 
 	int N = nlp->N;
 
-	int size;
+	hpipm_size_t size;
 
 	size = 0;
 
@@ -207,7 +207,7 @@ void d_set_default_ocp_nlp_hyb_arg(struct OCP_NLP_HYB_ARG *arg)
 
 
 // TODO eliminate x0 in QP !!!
-int MEMSIZE_OCP_NLP_HYB(struct OCP_NLP *nlp, struct OCP_NLP_HYB_ARG *arg)
+hpipm_size_t MEMSIZE_OCP_NLP_HYB(struct OCP_NLP *nlp, struct OCP_NLP_HYB_ARG *arg)
 	{
 
 	int ii;
@@ -241,7 +241,7 @@ int MEMSIZE_OCP_NLP_HYB(struct OCP_NLP *nlp, struct OCP_NLP_HYB_ARG *arg)
 
 	int *i_ptr;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct OCP_QP);
 	size += 1*sizeof(struct OCP_QP_SOL);

--- a/archive/ocp_nlp/d_ocp_nlp_ipm.c
+++ b/archive/ocp_nlp/d_ocp_nlp_ipm.c
@@ -94,12 +94,12 @@
 
 
 
-int d_memsize_ocp_nlp_ipm_arg(struct OCP_NLP *nlp)
+hpipm_size_t d_memsize_ocp_nlp_ipm_arg(struct OCP_NLP *nlp)
 	{
 
 	int N = nlp->N;
 
-	int size;
+	hpipm_size_t size;
 
 	size = 0;
 
@@ -140,7 +140,7 @@ void d_set_default_ocp_nlp_ipm_arg(struct OCP_NLP_IPM_ARG *arg)
 
 
 // TODO eliminate x0 in QP !!!
-int MEMSIZE_OCP_NLP_IPM(struct OCP_NLP *nlp, struct OCP_NLP_IPM_ARG *arg)
+hpipm_size_t MEMSIZE_OCP_NLP_IPM(struct OCP_NLP *nlp, struct OCP_NLP_IPM_ARG *arg)
 	{
 
 	int ii;
@@ -162,7 +162,7 @@ int MEMSIZE_OCP_NLP_IPM(struct OCP_NLP *nlp, struct OCP_NLP_IPM_ARG *arg)
 	
 	int *i_ptr;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct OCP_QP);
 	size += 1*sizeof(struct OCP_QP_SOL);

--- a/archive/ocp_nlp/d_ocp_nlp_sqp.c
+++ b/archive/ocp_nlp/d_ocp_nlp_sqp.c
@@ -92,12 +92,12 @@
 
 
 
-int d_memsize_ocp_nlp_sqp_arg(struct OCP_NLP *nlp)
+hpipm_size_t d_memsize_ocp_nlp_sqp_arg(struct OCP_NLP *nlp)
 	{
 
 	int N = nlp->N;
 
-	int size;
+	hpipm_size_t size;
 
 	size = 0;
 
@@ -192,7 +192,7 @@ void d_set_default_ocp_nlp_sqp_arg(struct OCP_NLP_SQP_ARG *arg)
 
 
 // TODO eliminate x0 in QP !!!
-int MEMSIZE_OCP_NLP_SQP(struct OCP_NLP *nlp, struct OCP_NLP_SQP_ARG *arg)
+hpipm_size_t MEMSIZE_OCP_NLP_SQP(struct OCP_NLP *nlp, struct OCP_NLP_SQP_ARG *arg)
 	{
 
 	int ii;
@@ -226,7 +226,7 @@ int MEMSIZE_OCP_NLP_SQP(struct OCP_NLP *nlp, struct OCP_NLP_SQP_ARG *arg)
 
 	int *i_ptr;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct OCP_QP);
 	size += 1*sizeof(struct OCP_QP_SOL);

--- a/archive/ocp_nlp/x_ocp_nlp_sol.c
+++ b/archive/ocp_nlp/x_ocp_nlp_sol.c
@@ -29,7 +29,7 @@
 
 
 
-int MEMSIZE_OCP_NLP_SOL(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
+hpipm_size_t MEMSIZE_OCP_NLP_SOL(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
 	{
 
 	int ii;
@@ -46,7 +46,7 @@ int MEMSIZE_OCP_NLP_SOL(int N, int *nx, int *nu, int *nb, int *ng, int *ns)
 	nvt += nu[ii]+nx[ii]+2*ns[ii];
 	nct += nb[ii]+ng[ii]+ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*(N+1)*sizeof(struct STRVEC); // ux lam t
 	size += 1*N*sizeof(struct STRVEC); // pi

--- a/archive/sim_core/d_irk_int.c
+++ b/archive/sim_core/d_irk_int.c
@@ -45,14 +45,14 @@
 
 
 
-int d_memsize_irk_int(struct d_rk_data *rk_data, int nx, int nf, int np)
+hpipm_size_t d_memsize_irk_int(struct d_rk_data *rk_data, int nx, int nf, int np)
 	{
 
 	int ns = rk_data->ns;
 
 	int nX = nx*(1+nf);
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*sizeof(struct blasfeo_dmat); // JG rG K
 

--- a/archive/test_d_nlp_ipm.c
+++ b/archive/test_d_nlp_ipm.c
@@ -96,14 +96,14 @@ struct d_linear_system
 	double *Bc;
 	int nx;
 	int nu;
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
-int d_memsize_linear_system(int nx, int nu)
+hpipm_size_t d_memsize_linear_system(int nx, int nu)
 	{
-	int size = 0;
+	hpipm_size_t size = 0;
 	size += (nx*nx+nx*nu)*sizeof(double);
 	return size;
 	}
@@ -250,7 +250,7 @@ int main()
 	d_print_mat(nx_, nx_, Ac, nx_);
 	d_print_mat(nx_, nu_, Bc, nx_);
 
-	int lin_sys_memsize = d_memsize_linear_system(nx_, nu_);
+	hpipm_size_t lin_sys_memsize = d_memsize_linear_system(nx_, nu_);
 	printf("\nlin_sys memsize = %d\n", lin_sys_memsize);
 	void *lin_sys_memory = malloc(lin_sys_memsize);
 
@@ -349,7 +349,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -664,7 +664,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -677,7 +677,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -709,7 +709,7 @@ int main()
 * ocp nlp ipm ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_d_nlp_sqp.c
+++ b/archive/test_d_nlp_sqp.c
@@ -96,14 +96,14 @@ struct d_linear_system
 	double *Bc;
 	int nx;
 	int nu;
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
-int d_memsize_linear_system(int nx, int nu)
+hpipm_size_t d_memsize_linear_system(int nx, int nu)
 	{
-	int size = 0;
+	hpipm_size_t size = 0;
 	size += (nx*nx+nx*nu)*sizeof(double);
 	return size;
 	}
@@ -250,7 +250,7 @@ int main()
 	d_print_mat(nx_, nx_, Ac, nx_);
 	d_print_mat(nx_, nu_, Bc, nx_);
 
-	int lin_sys_memsize = d_memsize_linear_system(nx_, nu_);
+	hpipm_size_t lin_sys_memsize = d_memsize_linear_system(nx_, nu_);
 	printf("\nlin_sys memsize = %d\n", lin_sys_memsize);
 	void *lin_sys_memory = malloc(lin_sys_memsize);
 
@@ -349,7 +349,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -679,7 +679,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -692,7 +692,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -722,7 +722,7 @@ int main()
 * ocp nlp sqp ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_d_pendulum_hyb.c
+++ b/archive/test_d_pendulum_hyb.c
@@ -258,7 +258,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -599,7 +599,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -612,7 +612,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -623,7 +623,7 @@ int main()
 * ocp nlp hyb arg
 ************************************************/	
 
-	int hyb_arg_size = d_memsize_ocp_nlp_hyb_arg(&nlp);
+	hpipm_size_t hyb_arg_size = d_memsize_ocp_nlp_hyb_arg(&nlp);
 	printf("\nipm arg size = %d\n", hyb_arg_size);
 	void *hyb_arg_mem = malloc(hyb_arg_size);
 
@@ -667,7 +667,7 @@ int main()
 * ocp nlp hyb ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_hyb(&nlp, &hyb_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_hyb(&nlp, &hyb_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_d_pendulum_ipm.c
+++ b/archive/test_d_pendulum_ipm.c
@@ -188,7 +188,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -529,7 +529,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -542,7 +542,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -553,7 +553,7 @@ int main()
 * ocp nlp ipm arg
 ************************************************/	
 
-	int ipm_arg_size = d_memsize_ocp_nlp_ipm_arg(&nlp);
+	hpipm_size_t ipm_arg_size = d_memsize_ocp_nlp_ipm_arg(&nlp);
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
@@ -581,7 +581,7 @@ int main()
 * ocp nlp ipm ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_d_pendulum_sqp.c
+++ b/archive/test_d_pendulum_sqp.c
@@ -188,7 +188,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -529,7 +529,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -542,7 +542,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -553,7 +553,7 @@ int main()
 * ocp nlp sqp arg
 ************************************************/	
 
-	int sqp_arg_size = d_memsize_ocp_nlp_sqp_arg(&nlp);
+	hpipm_size_t sqp_arg_size = d_memsize_ocp_nlp_sqp_arg(&nlp);
 	printf("\nipm arg size = %d\n", sqp_arg_size);
 	void *sqp_arg_mem = malloc(sqp_arg_size);
 
@@ -594,7 +594,7 @@ int main()
 * ocp nlp sqp ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_van_der_pol_hyb.c
+++ b/archive/test_van_der_pol_hyb.c
@@ -310,7 +310,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -624,7 +624,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -637,7 +637,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -648,7 +648,7 @@ int main()
 * ocp nlp hyb arg
 ************************************************/	
 
-	int hyb_arg_size = d_memsize_ocp_nlp_hyb_arg(&nlp);
+	hpipm_size_t hyb_arg_size = d_memsize_ocp_nlp_hyb_arg(&nlp);
 	printf("\nipm arg size = %d\n", hyb_arg_size);
 	void *hyb_arg_mem = malloc(hyb_arg_size);
 
@@ -692,7 +692,7 @@ int main()
 * ocp nlp hyb ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_hyb(&nlp, &hyb_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_hyb(&nlp, &hyb_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_van_der_pol_ipm.c
+++ b/archive/test_van_der_pol_ipm.c
@@ -263,7 +263,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -590,7 +590,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -603,7 +603,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -614,7 +614,7 @@ int main()
 * ocp nlp ipm arg
 ************************************************/	
 
-	int ipm_arg_size = d_memsize_ocp_nlp_ipm_arg(&nlp);
+	hpipm_size_t ipm_arg_size = d_memsize_ocp_nlp_ipm_arg(&nlp);
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
@@ -642,7 +642,7 @@ int main()
 * ocp nlp ipm ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_ipm(&nlp, &ipm_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/archive/test_van_der_pol_sqp.c
+++ b/archive/test_van_der_pol_sqp.c
@@ -221,7 +221,7 @@ int main()
 #endif
 
 	// erk data structure
-	int memsize_rk_data = d_memsize_rk_data(nsta);
+	hpipm_size_t memsize_rk_data = d_memsize_rk_data(nsta);
 	printf("\nmemsize rk data %d\n", memsize_rk_data);
 	void *memory_rk_data = malloc(memsize_rk_data);
 
@@ -535,7 +535,7 @@ int main()
 * ocp nlp
 ************************************************/	
 	
-	int nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_size = d_memsize_ocp_nlp(N, nx, nu, nb, ng, ns);
 	printf("\nnlpsize = %d\n", nlp_size);
 	void *nlp_mem = malloc(nlp_size);
 
@@ -548,7 +548,7 @@ int main()
 * ocp nlp sol
 ************************************************/	
 	
-	int nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t nlp_sol_size = d_memsize_ocp_nlp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nnlp sol size = %d\n", nlp_sol_size);
 	void *nlp_sol_mem = malloc(nlp_sol_size);
 
@@ -559,7 +559,7 @@ int main()
 * ocp nlp sqp arg
 ************************************************/	
 
-	int sqp_arg_size = d_memsize_ocp_nlp_sqp_arg(&nlp);
+	hpipm_size_t sqp_arg_size = d_memsize_ocp_nlp_sqp_arg(&nlp);
 	printf("\nipm arg size = %d\n", sqp_arg_size);
 	void *sqp_arg_mem = malloc(sqp_arg_size);
 
@@ -600,7 +600,7 @@ int main()
 * ocp nlp sqp ws
 ************************************************/	
 
-	int nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
+	hpipm_size_t nlp_ws_size = d_memsize_ocp_nlp_sqp(&nlp, &sqp_arg);
 	printf("\nnlp ws size = %d\n", nlp_ws_size);
 	void *nlp_ws_mem = malloc(nlp_ws_size);
 	

--- a/auxiliary/aux_mem.c
+++ b/auxiliary/aux_mem.c
@@ -42,35 +42,38 @@
 #include <immintrin.h>  // AVX
 #endif
 
-void hpipm_zero_memset(int memsize, void *mem)
+#include "hpipm_common.h"
+
+void hpipm_zero_memset(hpipm_size_t memsize, void *mem)
 	{
-	int ii;
-	int memsize_m8 = memsize/8; // sizeof(double) is 8
-	int memsize_r8 = memsize%8;
+	hpipm_size_t ii;
+	hpipm_size_t memsize_m8 = memsize/8; // sizeof(double) is 8
+	hpipm_size_t memsize_r8 = memsize%8;
 	double *double_ptr = mem;
 #ifdef TARGET_AVX
 	__m256d
 		y_zeros;
 	
 	y_zeros = _mm256_setzero_pd();
-
-	for(ii=0; ii<memsize_m8-7; ii+=8)
-		{
-		_mm256_storeu_pd( double_ptr+ii+0, y_zeros );
-		_mm256_storeu_pd( double_ptr+ii+4, y_zeros );
-		}
+	if(memsize_m8>7)
+		for(ii=0; ii<memsize_m8-7; ii+=8)
+			{
+			_mm256_storeu_pd( double_ptr+ii+0, y_zeros );
+			_mm256_storeu_pd( double_ptr+ii+4, y_zeros );
+			}
 #else
-	for(ii=0; ii<memsize_m8-7; ii+=8)
-		{
-		double_ptr[ii+0] = 0.0;
-		double_ptr[ii+1] = 0.0;
-		double_ptr[ii+2] = 0.0;
-		double_ptr[ii+3] = 0.0;
-		double_ptr[ii+4] = 0.0;
-		double_ptr[ii+5] = 0.0;
-		double_ptr[ii+6] = 0.0;
-		double_ptr[ii+7] = 0.0;
-		}
+	if(memsize_m8>7)
+		for(ii=0; ii<memsize_m8-7; ii+=8)
+			{
+			double_ptr[ii+0] = 0.0;
+			double_ptr[ii+1] = 0.0;
+			double_ptr[ii+2] = 0.0;
+			double_ptr[ii+3] = 0.0;
+			double_ptr[ii+4] = 0.0;
+			double_ptr[ii+5] = 0.0;
+			double_ptr[ii+6] = 0.0;
+			double_ptr[ii+7] = 0.0;
+			}
 #endif
 	for(; ii<memsize_m8; ii++)
 		{

--- a/benchmark/d_benchmark.h
+++ b/benchmark/d_benchmark.h
@@ -108,11 +108,11 @@ struct benchmark_to_hpipm
     double *d_ug0;
   };
 
-int d_memsize_benchmark_qp(int nv, int ne, int nc);
+hpipm_size_t d_memsize_benchmark_qp(int nv, int ne, int nc);
 
 void d_create_benchmark_qp(int nv, int ne, int nc, struct benchmark_qp *qp, void *mem);
 
-int d_memsize_benchmark_to_hpipm(int nv, int ne, int nc);
+hpipm_size_t d_memsize_benchmark_to_hpipm(int nv, int ne, int nc);
 
 void d_create_benchmark_to_hpipm(int nv, int ne, int nc, struct benchmark_to_hpipm *tran_space, void *mem);
 

--- a/benchmark/test_d_benchmark.c
+++ b/benchmark/test_d_benchmark.c
@@ -50,10 +50,10 @@
 
 
 
-int d_memsize_benchmark_qp(int nv, int ne, int nc)
+hpipm_size_t d_memsize_benchmark_qp(int nv, int ne, int nc)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	// size of double, int
 	size += nv * nv * sizeof(double);		 // H
@@ -105,10 +105,10 @@ void d_create_benchmark_qp(int nv, int ne, int nc, struct benchmark_qp *qp, void
 
 
 
-int d_memsize_benchmark_to_hpipm(int nv, int ne, int nc)
+hpipm_size_t d_memsize_benchmark_to_hpipm(int nv, int ne, int nc)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	// size of double, int
 	size += nv * sizeof(int); // idxb
@@ -473,7 +473,7 @@ int main()
 		************************************************/
 
 		int nc = ng-ne; // inequality constraint
-		int benchmark_size = d_memsize_benchmark_qp(nv, ne, nc);
+		hpipm_size_t benchmark_size = d_memsize_benchmark_qp(nv, ne, nc);
 		void *benchmark_mem = calloc(benchmark_size,1);
 
 		struct benchmark_qp qp_bench;
@@ -502,7 +502,7 @@ int main()
 		* benchmark to hpipm workspace
 		************************************************/
 
-		int tran_size = d_memsize_benchmark_to_hpipm(nv, ne, nc);
+		hpipm_size_t tran_size = d_memsize_benchmark_to_hpipm(nv, ne, nc);
 		void *tran_mem = calloc(tran_size,1);
 
 		struct benchmark_to_hpipm tran_space;
@@ -514,7 +514,7 @@ int main()
 
 		// double
 
-		int qp_dim_size = d_dense_qp_dim_memsize();
+		hpipm_size_t qp_dim_size = d_dense_qp_dim_memsize();
 		void *qp_dim_mem = calloc(qp_dim_size, 1);
 
 		struct d_dense_qp_dim dim;
@@ -525,7 +525,7 @@ int main()
 
 		// single
 
-		int s_qp_dim_size = s_dense_qp_dim_memsize();
+		hpipm_size_t s_qp_dim_size = s_dense_qp_dim_memsize();
 		void *s_qp_dim_mem = calloc(s_qp_dim_size, 1);
 
 		struct s_dense_qp_dim s_dim;
@@ -539,7 +539,7 @@ int main()
 
 		// double
 
-		int qp_size = d_dense_qp_memsize(&dim);
+		hpipm_size_t qp_size = d_dense_qp_memsize(&dim);
 		void *qp_mem = calloc(qp_size, 1);
 
 		struct d_dense_qp d_qp;
@@ -551,7 +551,7 @@ int main()
 		double reg = 0e-8;
 		blasfeo_ddiare(nv, reg, d_qp.Hv, 0, 0);
 
-		int H_fact_size = blasfeo_memsize_dmat(nv, nv);
+		hpipm_size_t H_fact_size = blasfeo_memsize_dmat(nv, nv);
 		void *H_fact_mem; v_zeros_align(&H_fact_mem, H_fact_size);
 
 		struct blasfeo_dmat H_fact;
@@ -566,7 +566,7 @@ int main()
 
 		// single
 
-		int s_qp_size = s_dense_qp_memsize(&s_dim);
+		hpipm_size_t s_qp_size = s_dense_qp_memsize(&s_dim);
 		void *s_qp_mem = calloc(s_qp_size, 1);
 
 		struct s_dense_qp s_qpd_hpipm;
@@ -580,7 +580,7 @@ int main()
 
 		// double
 
-		int qp_sol_size = d_dense_qp_sol_memsize(&dim);
+		hpipm_size_t qp_sol_size = d_dense_qp_sol_memsize(&dim);
 		void *qp_sol_mem = calloc(qp_sol_size,1);
 
 		struct d_dense_qp_sol qpd_sol;
@@ -588,7 +588,7 @@ int main()
 
 		// single
 
-		int s_qp_sol_size = s_dense_qp_sol_memsize(&s_dim);
+		hpipm_size_t s_qp_sol_size = s_dense_qp_sol_memsize(&s_dim);
 		void *s_qp_sol_mem = calloc(s_qp_sol_size,1);
 
 		struct s_dense_qp_sol s_qpd_sol;
@@ -605,7 +605,7 @@ int main()
 
 		// double
 
-		int ipm_arg_size = d_dense_qp_ipm_arg_memsize(&dim);
+		hpipm_size_t ipm_arg_size = d_dense_qp_ipm_arg_memsize(&dim);
 		void *ipm_arg_mem = calloc(ipm_arg_size,1);
 
 		struct d_dense_qp_ipm_arg d_arg;
@@ -655,7 +655,7 @@ int main()
 
 		// single
 
-		int s_ipm_arg_size = s_dense_qp_ipm_arg_memsize(&s_dim);
+		hpipm_size_t s_ipm_arg_size = s_dense_qp_ipm_arg_memsize(&s_dim);
 		void *s_ipm_arg_mem = calloc(s_ipm_arg_size,1);
 
 		struct s_dense_qp_ipm_arg s_argd;
@@ -689,7 +689,7 @@ int main()
 
 		// double
 
-		int ipm_size = d_dense_qp_ipm_ws_memsize(&dim, &d_arg);
+		hpipm_size_t ipm_size = d_dense_qp_ipm_ws_memsize(&dim, &d_arg);
 
 		void *ipm_mem = calloc(ipm_size,1);
 		struct d_dense_qp_ipm_ws d_ws;
@@ -728,7 +728,7 @@ int main()
 
 		// single
 
-		int s_ipm_size = s_dense_qp_ipm_ws_memsize(&s_dim, &s_argd);
+		hpipm_size_t s_ipm_size = s_dense_qp_ipm_ws_memsize(&s_dim, &s_argd);
 
 		void *s_ipm_mem = calloc(s_ipm_size,1);
 		struct s_dense_qp_ipm_ws s_workspace;

--- a/cond/d_elim_x0.c
+++ b/cond/d_elim_x0.c
@@ -53,7 +53,7 @@ struct d_elim_x0_workspace
 	struct blasfeo_dvec *b0;
 	struct blasfeo_dvec *ux0;
 	int nx0;
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -65,7 +65,7 @@ void MEMSIZE_ELIM_X0(struct OCP_QP *qp)
 	int *nx = qp->nx;
 	int *nu = qp->nu;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct STRMAT); // BAbt0_i
 	size += 2*sizeof(struct STRVEC); // b0 x0

--- a/cond/x_cast_qcqp.c
+++ b/cond/x_cast_qcqp.c
@@ -114,8 +114,8 @@ void CAST_QCQP_COND(struct OCP_QCQP *ocp_qp, struct DENSE_QCQP *dense_qp)
 	int *ng = ocp_qp->dim->ng;
 	int *nq = ocp_qp->dim->nq;
 
-	int nvc = dense_qp->dim->nv;
-	int nec = dense_qp->dim->ne;
+//	int nvc = dense_qp->dim->nv;
+//	int nec = dense_qp->dim->ne;
 	int nbc = dense_qp->dim->nb;
 	int ngc = dense_qp->dim->ng;
 	int nqc = dense_qp->dim->nq;

--- a/cond/x_cond.c
+++ b/cond/x_cond.c
@@ -89,10 +89,10 @@ void COND_QP_COMPUTE_DIM(struct OCP_QP_DIM *ocp_dim, struct DENSE_QP_DIM *dense_
 
 
 
-int COND_QP_ARG_MEMSIZE()
+hpipm_size_t COND_QP_ARG_MEMSIZE()
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	return size;
 
@@ -193,7 +193,7 @@ void COND_QP_ARG_SET_COMP_DUAL_SOL_INEQ(int value, struct COND_QP_ARG *cond_arg)
 
 
 
-int COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg)
+hpipm_size_t COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg)
 	{
 
 	int ii;
@@ -235,7 +235,7 @@ int COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg)
 	nbM = nb[ii]>nbM ? nb[ii] : nbM;
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*N*sizeof(struct STRMAT); // Gamma
 	size += 1*N*sizeof(struct STRVEC); // Gammab
@@ -299,7 +299,7 @@ void COND_QP_WS_CREATE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg,
 	size_t s_ptr;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = COND_QP_WS_MEMSIZE(ocp_dim, cond_arg);
+	hpipm_size_t memsize = COND_QP_WS_MEMSIZE(ocp_dim, cond_arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int N = ocp_dim->N;

--- a/cond/x_cond_qcqp.c
+++ b/cond/x_cond_qcqp.c
@@ -100,10 +100,10 @@ void COND_QCQP_COMPUTE_DIM(struct OCP_QCQP_DIM *ocp_dim, struct DENSE_QCQP_DIM *
 
 
 
-int COND_QCQP_ARG_MEMSIZE()
+hpipm_size_t COND_QCQP_ARG_MEMSIZE()
 	{
 
-	int size = 0;
+        hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct COND_QP_ARG);
 	size += 1*COND_QP_ARG_MEMSIZE();
@@ -124,7 +124,7 @@ void COND_QCQP_ARG_CREATE(struct COND_QCQP_ARG *cond_arg, void *mem)
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = COND_QCQP_ARG_MEMSIZE();
+	hpipm_size_t memsize = COND_QCQP_ARG_MEMSIZE();
 	hpipm_zero_memset(memsize, mem);
 
 	struct COND_QP_ARG *arg_ptr = mem;
@@ -209,10 +209,10 @@ void COND_QCQP_ARG_SET_COND_LAST_STAGE(int cond_last_stage, struct COND_QCQP_ARG
 
 
 
-int COND_QCQP_WS_MEMSIZE(struct OCP_QCQP_DIM *ocp_dim, struct COND_QCQP_ARG *cond_arg)
+hpipm_size_t COND_QCQP_WS_MEMSIZE(struct OCP_QCQP_DIM *ocp_dim, struct COND_QCQP_ARG *cond_arg)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct COND_QP_WS);
 	size += 1*COND_QP_WS_MEMSIZE(ocp_dim->qp_dim, cond_arg->qp_arg);
@@ -298,7 +298,7 @@ void COND_QCQP_WS_CREATE(struct OCP_QCQP_DIM *ocp_dim, struct COND_QCQP_ARG *con
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = COND_QCQP_WS_MEMSIZE(ocp_dim, cond_arg);
+	hpipm_size_t memsize = COND_QCQP_WS_MEMSIZE(ocp_dim, cond_arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int N = ocp_dim->N;

--- a/cond/x_cond_qcqp.c
+++ b/cond/x_cond_qcqp.c
@@ -103,7 +103,7 @@ void COND_QCQP_COMPUTE_DIM(struct OCP_QCQP_DIM *ocp_dim, struct DENSE_QCQP_DIM *
 hpipm_size_t COND_QCQP_ARG_MEMSIZE()
 	{
 
-        hpipm_size_t size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct COND_QP_ARG);
 	size += 1*COND_QP_ARG_MEMSIZE();

--- a/cond/x_part_cond.c
+++ b/cond/x_part_cond.c
@@ -86,8 +86,8 @@ void PART_COND_QP_COMPUTE_DIM(struct OCP_QP_DIM *ocp_dim, int *block_size, struc
 
 	int ii, jj;
 
-	int nbb; // box constr that remain box constr
-	int nbg; // box constr that becomes general constr
+//	int nbb; // box constr that remain box constr
+//	int nbg; // box constr that becomes general constr
 	int N_tmp = 0; // temporary sum of block size
 	// first stages
 	for(ii=0; ii<N2; ii++)
@@ -151,12 +151,12 @@ void PART_COND_QP_COMPUTE_DIM(struct OCP_QP_DIM *ocp_dim, int *block_size, struc
 
 
 
-int PART_COND_QP_ARG_MEMSIZE(int N2)
+hpipm_size_t PART_COND_QP_ARG_MEMSIZE(int N2)
 	{
 
 	int ii;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (N2+1)*sizeof(struct COND_QP_ARG);
 
@@ -313,7 +313,7 @@ void PART_COND_QP_ARG_SET_COMP_DUAL_SOL_INEQ(int value, struct PART_COND_QP_ARG 
 
 
 
-int PART_COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, int *block_size, struct OCP_QP_DIM *part_dense_dim, struct PART_COND_QP_ARG *part_cond_arg)
+hpipm_size_t PART_COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, int *block_size, struct OCP_QP_DIM *part_dense_dim, struct PART_COND_QP_ARG *part_cond_arg)
 	{
 
 	struct OCP_QP_DIM tmp_ocp_dim;
@@ -323,7 +323,7 @@ int PART_COND_QP_WS_MEMSIZE(struct OCP_QP_DIM *ocp_dim, int *block_size, struct 
 	int N = ocp_dim->N;
 	int N2 = part_dense_dim->N;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (N2+1)*sizeof(struct COND_QP_ARG_WS);
 

--- a/cond/x_part_cond_qcqp.c
+++ b/cond/x_part_cond_qcqp.c
@@ -189,12 +189,12 @@ void PART_COND_QCQP_COMPUTE_DIM(struct OCP_QCQP_DIM *ocp_dim, int *block_size, s
 
 
 
-int PART_COND_QCQP_ARG_MEMSIZE(int N2)
+hpipm_size_t PART_COND_QCQP_ARG_MEMSIZE(int N2)
 	{
 
 	int ii;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (N2+1)*sizeof(struct COND_QCQP_ARG);
 
@@ -297,7 +297,7 @@ void PART_COND_QCQP_ARG_SET_RIC_ALG(int ric_alg, struct PART_COND_QCQP_ARG *part
 
 
 
-int PART_COND_QCQP_WS_MEMSIZE(struct OCP_QCQP_DIM *ocp_dim, int *block_size, struct OCP_QCQP_DIM *part_dense_dim, struct PART_COND_QCQP_ARG *part_cond_arg)
+hpipm_size_t PART_COND_QCQP_WS_MEMSIZE(struct OCP_QCQP_DIM *ocp_dim, int *block_size, struct OCP_QCQP_DIM *part_dense_dim, struct PART_COND_QCQP_ARG *part_cond_arg)
 	{
 
 	struct OCP_QCQP_DIM tmp_ocp_qcqp_dim;
@@ -308,7 +308,7 @@ int PART_COND_QCQP_WS_MEMSIZE(struct OCP_QCQP_DIM *ocp_dim, int *block_size, str
 	int N = ocp_dim->N;
 	int N2 = part_dense_dim->N;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (N2+1)*sizeof(struct COND_QCQP_ARG_WS);
 

--- a/dense_qp/x_dense_qcqp.c
+++ b/dense_qp/x_dense_qcqp.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QCQP_MEMSIZE(struct DENSE_QCQP_DIM *dim)
+hpipm_size_t DENSE_QCQP_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	{
 
 	int nv = dim->nv;
@@ -45,7 +45,7 @@ int DENSE_QCQP_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	int nq = dim->nq;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 6*sizeof(struct STRVEC); // gz b d m Z d_mask
 	size += (nq+3)*sizeof(struct STRMAT); // Hv A Ct Hq
@@ -78,7 +78,7 @@ void DENSE_QCQP_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP *qp, void *
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QCQP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/dense_qp/x_dense_qcqp_dim.c
+++ b/dense_qp/x_dense_qcqp_dim.c
@@ -35,10 +35,10 @@
 
 
 
-int DENSE_QCQP_DIM_MEMSIZE()
+hpipm_size_t DENSE_QCQP_DIM_MEMSIZE()
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct DENSE_QP_DIM);
 	size += 1*DENSE_QP_DIM_MEMSIZE();
@@ -56,7 +56,7 @@ void DENSE_QCQP_DIM_CREATE(struct DENSE_QCQP_DIM *dim, void *mem)
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_DIM_MEMSIZE();
+	hpipm_size_t memsize = DENSE_QCQP_DIM_MEMSIZE();
 	hpipm_zero_memset(memsize, mem);
 
 	// qp_dim struct

--- a/dense_qp/x_dense_qcqp_ipm.c
+++ b/dense_qp/x_dense_qcqp_ipm.c
@@ -35,10 +35,10 @@
 
 
 
-int DENSE_QCQP_IPM_ARG_MEMSIZE(struct DENSE_QCQP_DIM *dim)
+hpipm_size_t DENSE_QCQP_IPM_ARG_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct DENSE_QP_IPM_ARG);
 	size += 1*DENSE_QP_IPM_ARG_MEMSIZE(dim->qp_dim);
@@ -59,7 +59,7 @@ void DENSE_QCQP_IPM_ARG_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_IPM_ARG_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QCQP_IPM_ARG_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// qp_dim struct
@@ -498,12 +498,12 @@ void DENSE_QCQP_IPM_ARG_SET_T_LAM_MIN(int *value, struct DENSE_QCQP_IPM_ARG *arg
 
 
 
-int DENSE_QCQP_IPM_WS_MEMSIZE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM_ARG *arg)
+hpipm_size_t DENSE_QCQP_IPM_WS_MEMSIZE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM_ARG *arg)
 	{
 
 	int nv = dim->nv;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct DENSE_QP_IPM_WS);
 	size += 1*DENSE_QP_IPM_WS_MEMSIZE(dim->qp_dim, arg->qp_arg);
@@ -538,7 +538,7 @@ void DENSE_QCQP_IPM_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM_
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = DENSE_QCQP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int nv = dim->nv;

--- a/dense_qp/x_dense_qcqp_res.c
+++ b/dense_qp/x_dense_qcqp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QCQP_RES_MEMSIZE(struct DENSE_QCQP_DIM *dim)
+hpipm_size_t DENSE_QCQP_RES_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -49,7 +49,7 @@ int DENSE_QCQP_RES_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	int nq = dim->nq;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 4*sizeof(struct STRVEC); // res_g res_b res_d res_m
 
@@ -73,7 +73,7 @@ void DENSE_QCQP_RES_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES *re
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QCQP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -138,7 +138,7 @@ void DENSE_QCQP_RES_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES *re
 
 
 
-int DENSE_QCQP_RES_WS_MEMSIZE(struct DENSE_QCQP_DIM *dim)
+hpipm_size_t DENSE_QCQP_RES_WS_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -152,7 +152,7 @@ int DENSE_QCQP_RES_WS_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	int nq = dim->nq;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 7*sizeof(struct STRVEC); // 2*tmp_nv 2*tmp_nbgq tmp_ns q_fun q_adj
 
@@ -177,7 +177,7 @@ void DENSE_QCQP_RES_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES_
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QCQP_RES_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/dense_qp/x_dense_qcqp_sol.c
+++ b/dense_qp/x_dense_qcqp_sol.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QCQP_SOL_MEMSIZE(struct DENSE_QCQP_DIM *dim)
+hpipm_size_t DENSE_QCQP_SOL_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	{
 
 	int nv = dim->nv;
@@ -45,7 +45,7 @@ int DENSE_QCQP_SOL_MEMSIZE(struct DENSE_QCQP_DIM *dim)
 	int nq = dim->nq;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 4*sizeof(struct STRVEC); // v pi lam t
 
@@ -69,7 +69,7 @@ void DENSE_QCQP_SOL_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_SOL *qp
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QCQP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QCQP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/dense_qp/x_dense_qp.c
+++ b/dense_qp/x_dense_qp.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QP_MEMSIZE(struct DENSE_QP_DIM *dim)
+hpipm_size_t DENSE_QP_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
 
 	int nv = dim->nv;
@@ -44,7 +44,7 @@ int DENSE_QP_MEMSIZE(struct DENSE_QP_DIM *dim)
 	int ng = dim->ng;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 6*sizeof(struct STRVEC); // gz b d m Z d_mask
 	size += 3*sizeof(struct STRMAT); // Hv A Ct
@@ -75,7 +75,7 @@ void DENSE_QP_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP *qp, void *mem)
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QP_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/dense_qp/x_dense_qp_dim.c
+++ b/dense_qp/x_dense_qp_dim.c
@@ -35,10 +35,10 @@
 
 
 
-int DENSE_QP_DIM_MEMSIZE()
+hpipm_size_t DENSE_QP_DIM_MEMSIZE()
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size = (size+8-1)/8*8;
 
@@ -52,7 +52,7 @@ void DENSE_QP_DIM_CREATE(struct DENSE_QP_DIM *dim, void *mem)
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-//	int memsize = DENSE_QP_DIM_MEMSIZE();
+//	hpipm_size_t memsize = DENSE_QP_DIM_MEMSIZE();
 //	hpipm_zero_memset(memsize, mem);
 
 	dim->memsize = DENSE_QP_DIM_MEMSIZE();

--- a/dense_qp/x_dense_qp_ipm.c
+++ b/dense_qp/x_dense_qp_ipm.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QP_IPM_ARG_MEMSIZE(struct DENSE_QP_DIM *dim)
+hpipm_size_t DENSE_QP_IPM_ARG_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
 
 	return 0;
@@ -48,7 +48,7 @@ void DENSE_QP_IPM_ARG_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-//	int memsize = DENSE_QP_IPM_ARG_MEMSIZE(dim);
+//	hpipm_size_t memsize = DENSE_QP_IPM_ARG_MEMSIZE(dim);
 //	hpipm_zero_memset(memsize, mem);
 
 	arg->memsize = 0;
@@ -508,7 +508,7 @@ void DENSE_QP_IPM_ARG_SET_T_LAM_MIN(int *value, struct DENSE_QP_IPM_ARG *arg)
 
 
 
-int DENSE_QP_IPM_WS_MEMSIZE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *arg)
+hpipm_size_t DENSE_QP_IPM_WS_MEMSIZE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *arg)
 	{
 
 	int nv = dim->nv;
@@ -517,7 +517,7 @@ int DENSE_QP_IPM_WS_MEMSIZE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *a
 	int ng = dim->ng;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct CORE_QP_IPM_WORKSPACE);
 	size += 1*MEMSIZE_CORE_QP_IPM(nv+2*ns, ne, 2*nb+2*ng+2*ns);
@@ -639,7 +639,7 @@ void DENSE_QP_IPM_WS_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *a
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = DENSE_QP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int nv = dim->nv;

--- a/dense_qp/x_dense_qp_res.c
+++ b/dense_qp/x_dense_qp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QP_RES_MEMSIZE(struct DENSE_QP_DIM *dim)
+hpipm_size_t DENSE_QP_RES_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
 
 	// loop index
@@ -48,7 +48,7 @@ int DENSE_QP_RES_MEMSIZE(struct DENSE_QP_DIM *dim)
 	int ng = dim->ng;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 4*sizeof(struct STRVEC); // res_g res_b res_d res_m
 
@@ -72,7 +72,7 @@ void DENSE_QP_RES_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES *res, voi
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -136,7 +136,7 @@ void DENSE_QP_RES_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES *res, voi
 
 
 
-int DENSE_QP_RES_WS_MEMSIZE(struct DENSE_QP_DIM *dim)
+hpipm_size_t DENSE_QP_RES_WS_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
 
 	// loop index
@@ -149,7 +149,7 @@ int DENSE_QP_RES_WS_MEMSIZE(struct DENSE_QP_DIM *dim)
 	int ng = dim->ng;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*sizeof(struct STRVEC); // 2*tmp_nbg tmp_ns
 
@@ -172,11 +172,12 @@ void DENSE_QP_RES_WS_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES_WS *ws
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QP_RES_WS_MEMSIZE(dim);
-	int memsize_m8 = memsize/8; // sizeof(double) is 8
-//	int memsize_r8 = memsize - 8*memsize_m8;
+	hpipm_size_t memsize = DENSE_QP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize_m8 = memsize/8; // sizeof(double) is 8
+//	hpipm_size_t memsize_r8 = memsize - 8*memsize_m8;
 	double *double_ptr = mem;
 	// XXX exploit that it is multiple of 64 bytes !!!!!
+	if(memsize_m8>7)
 	for(ii=0; ii<memsize_m8-7; ii+=8)
 		{
 		double_ptr[ii+0] = 0.0;

--- a/dense_qp/x_dense_qp_sol.c
+++ b/dense_qp/x_dense_qp_sol.c
@@ -35,7 +35,7 @@
 
 
 
-int DENSE_QP_SOL_MEMSIZE(struct DENSE_QP_DIM *dim)
+hpipm_size_t DENSE_QP_SOL_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
 
 	int nv = dim->nv;
@@ -44,7 +44,7 @@ int DENSE_QP_SOL_MEMSIZE(struct DENSE_QP_DIM *dim)
 	int ng = dim->ng;
 	int ns = dim->ns;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 4*sizeof(struct STRVEC); // v pi lam t
 
@@ -68,7 +68,7 @@ void DENSE_QP_SOL_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_SOL *qp_sol, 
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = DENSE_QP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = DENSE_QP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/examples/c/example_d_ocp_qcqp_part_cond.c
+++ b/examples/c/example_d_ocp_qcqp_part_cond.c
@@ -123,7 +123,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qcqp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qcqp_dim dim;
@@ -152,7 +152,7 @@ int main()
 	// horizon length of partially condensed OCP QP
 	int N2 = 1;
 
-	int dim_size2 = d_ocp_qcqp_dim_memsize(N2);
+	hpipm_size_t dim_size2 = d_ocp_qcqp_dim_memsize(N2);
 	void *dim_mem2 = malloc(dim_size2);
 
 	struct d_ocp_qcqp_dim dim2;
@@ -171,7 +171,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qcqp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qcqp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qcqp qp;
@@ -232,7 +232,7 @@ int main()
 * ocp qp part cond
 ************************************************/
 
-	int qp_size2 = d_ocp_qcqp_memsize(&dim2);
+	hpipm_size_t qp_size2 = d_ocp_qcqp_memsize(&dim2);
 	void *qp_mem2 = malloc(qp_size2);
 
 	struct d_ocp_qcqp qp2;
@@ -242,7 +242,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qcqp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qcqp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qcqp_sol qp_sol;
@@ -252,7 +252,7 @@ int main()
 * ocp qp sol part cond
 ************************************************/
 
-	int qp_sol_size2 = d_ocp_qcqp_sol_memsize(&dim2);
+	hpipm_size_t qp_sol_size2 = d_ocp_qcqp_sol_memsize(&dim2);
 	void *qp_sol_mem2 = malloc(qp_sol_size2);
 
 	struct d_ocp_qcqp_sol qp_sol2;
@@ -262,7 +262,7 @@ int main()
 * part cond arg
 ************************************************/
 
-	int part_cond_arg_size = d_part_cond_qcqp_arg_memsize(dim2.N);
+	hpipm_size_t part_cond_arg_size = d_part_cond_qcqp_arg_memsize(dim2.N);
 	void *part_cond_arg_mem = malloc(part_cond_arg_size);
 
 	struct d_part_cond_qcqp_arg part_cond_arg;
@@ -276,7 +276,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qcqp_ipm_arg arg;
@@ -298,7 +298,7 @@ int main()
 * part cond workspace
 ************************************************/
 
-	int part_cond_size = d_part_cond_qcqp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
+	hpipm_size_t part_cond_size = d_part_cond_qcqp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
 	void *part_cond_mem = malloc(part_cond_size);
 
 	struct d_part_cond_qcqp_ws part_cond_ws;
@@ -308,7 +308,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qcqp_ipm_ws_memsize(&dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qcqp_ipm_ws_memsize(&dim2, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qcqp_ipm_ws workspace;

--- a/examples/c/example_d_ocp_qp.c
+++ b/examples/c/example_d_ocp_qp.c
@@ -118,7 +118,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -130,7 +130,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qp qp;
@@ -142,7 +142,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qp_sol qp_sol;
@@ -152,7 +152,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -177,7 +177,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_ws workspace;

--- a/examples/c/example_d_ocp_qp_part_cond.c
+++ b/examples/c/example_d_ocp_qp_part_cond.c
@@ -114,7 +114,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -129,7 +129,7 @@ int main()
 	// horizon length of partially condensed OCP QP
 	int N2 = 2;
 
-	int dim_size2 = d_ocp_qp_dim_memsize(N2);
+	hpipm_size_t dim_size2 = d_ocp_qp_dim_memsize(N2);
 	void *dim_mem2 = malloc(dim_size2);
 
 	struct d_ocp_qp_dim dim2;
@@ -148,7 +148,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qp qp;
@@ -160,7 +160,7 @@ int main()
 * ocp qp part cond
 ************************************************/
 
-	int qp_size2 = d_ocp_qp_memsize(&dim2);
+	hpipm_size_t qp_size2 = d_ocp_qp_memsize(&dim2);
 	void *qp_mem2 = malloc(qp_size2);
 
 	struct d_ocp_qp qp2;
@@ -170,7 +170,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qp_sol qp_sol;
@@ -180,7 +180,7 @@ int main()
 * ocp qp sol part cond
 ************************************************/
 
-	int qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
+	hpipm_size_t qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
 	void *qp_sol_mem2 = malloc(qp_sol_size2);
 
 	struct d_ocp_qp_sol qp_sol2;
@@ -190,7 +190,7 @@ int main()
 * part cond arg
 ************************************************/
 
-	int part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
+	hpipm_size_t part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
 	void *part_cond_arg_mem = malloc(part_cond_arg_size);
 
 	struct d_part_cond_qp_arg part_cond_arg;
@@ -204,7 +204,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -226,7 +226,7 @@ int main()
 * part cond workspace
 ************************************************/
 
-	int part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
+	hpipm_size_t part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
 	void *part_cond_mem = malloc(part_cond_size);
 
 	struct d_part_cond_qp_ws part_cond_ws;
@@ -236,7 +236,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_ws workspace;

--- a/examples/c/example_d_ocp_qp_part_cond_sens.c
+++ b/examples/c/example_d_ocp_qp_part_cond_sens.c
@@ -114,7 +114,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -129,7 +129,7 @@ int main()
 	// horizon length of partially condensed OCP QP
 	int N2 = 2;
 
-	int dim_size2 = d_ocp_qp_dim_memsize(N2);
+	hpipm_size_t dim_size2 = d_ocp_qp_dim_memsize(N2);
 	void *dim_mem2 = malloc(dim_size2);
 
 	struct d_ocp_qp_dim dim2;
@@ -148,7 +148,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qp qp;
@@ -160,7 +160,7 @@ int main()
 * ocp qp part cond
 ************************************************/
 
-	int qp_size2 = d_ocp_qp_memsize(&dim2);
+	hpipm_size_t qp_size2 = d_ocp_qp_memsize(&dim2);
 	void *qp_mem2 = malloc(qp_size2);
 
 	struct d_ocp_qp qp2;
@@ -170,7 +170,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qp_sol qp_sol;
@@ -180,7 +180,7 @@ int main()
 * ocp qp sol part cond
 ************************************************/
 
-	int qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
+	hpipm_size_t qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
 	void *qp_sol_mem2 = malloc(qp_sol_size2);
 
 	struct d_ocp_qp_sol qp_sol2;
@@ -190,7 +190,7 @@ int main()
 * part cond arg
 ************************************************/
 
-	int part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
+	hpipm_size_t part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
 	void *part_cond_arg_mem = malloc(part_cond_arg_size);
 
 	struct d_part_cond_qp_arg part_cond_arg;
@@ -205,7 +205,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -227,7 +227,7 @@ int main()
 * part cond workspace
 ************************************************/
 
-	int part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
+	hpipm_size_t part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
 	void *part_cond_mem = malloc(part_cond_size);
 
 	struct d_part_cond_qp_ws part_cond_ws;
@@ -237,7 +237,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_ws workspace;
@@ -391,12 +391,12 @@ int main()
 * residuals of original QP
 ************************************************/
 	
-	int res_size = d_ocp_qp_res_memsize(&dim);
+	hpipm_size_t res_size = d_ocp_qp_res_memsize(&dim);
 	void *res_mem = malloc(res_size);
 	struct d_ocp_qp_res res;
 	d_ocp_qp_res_create(&dim, &res, res_mem);
 
-	int res_ws_size = d_ocp_qp_res_ws_memsize(&dim);
+	hpipm_size_t res_ws_size = d_ocp_qp_res_ws_memsize(&dim);
 	void *res_ws_mem = malloc(res_ws_size);
 	struct d_ocp_qp_res_ws res_ws;
 	d_ocp_qp_res_ws_create(&dim, &res_ws, res_ws_mem);

--- a/examples/c/example_d_ocp_qp_sens.c
+++ b/examples/c/example_d_ocp_qp_sens.c
@@ -120,7 +120,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -132,7 +132,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qp qp;
@@ -144,7 +144,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qp_sol qp_sol;
@@ -154,7 +154,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -176,7 +176,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_ws workspace;

--- a/examples/c/example_d_ocp_qp_unconstr.c
+++ b/examples/c/example_d_ocp_qp_unconstr.c
@@ -189,7 +189,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -201,7 +201,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	void *qp_mem = malloc(qp_size);
 
 	struct d_ocp_qp qp;
@@ -213,7 +213,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
 	struct d_ocp_qp_sol qp_sol;
@@ -223,7 +223,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -245,7 +245,7 @@ int main()
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_ws workspace;

--- a/include/hpipm_aux_mem.h
+++ b/include/hpipm_aux_mem.h
@@ -36,11 +36,13 @@
 #ifndef HPIPM_AUX_MEM_H_
 #define HPIPM_AUX_MEM_H_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void hpipm_zero_memset(int memsize, void *mem);
+void hpipm_zero_memset(hpipm_size_t memsize, void *mem);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/hpipm_common.h
+++ b/include/hpipm_common.h
@@ -38,13 +38,13 @@
 #ifndef HPIPM_COMMON_H_
 #define HPIPM_COMMON_H_
 
-
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
+typedef size_t hpipm_size_t;
 
 enum hpipm_mode
 	{

--- a/include/hpipm_d_cond.h
+++ b/include/hpipm_d_cond.h
@@ -63,7 +63,7 @@ struct d_cond_qp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -80,13 +80,13 @@ struct d_cond_qp_ws
 	struct blasfeo_dvec *tmp_nbgM;
 	struct blasfeo_dvec *tmp_nuxM;
 	int bs; // block size
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_cond_qp_arg_memsize();
+hpipm_size_t d_cond_qp_arg_memsize();
 //
 void d_cond_qp_arg_create(struct d_cond_qp_arg *cond_arg, void *mem);
 //
@@ -107,7 +107,7 @@ void d_cond_qp_arg_set_comp_dual_sol_ineq(int value, struct d_cond_qp_arg *cond_
 //
 void d_cond_qp_compute_dim(struct d_ocp_qp_dim *ocp_dim, struct d_dense_qp_dim *dense_dim);
 //
-int d_cond_qp_ws_memsize(struct d_ocp_qp_dim *ocp_dim, struct d_cond_qp_arg *cond_arg);
+hpipm_size_t d_cond_qp_ws_memsize(struct d_ocp_qp_dim *ocp_dim, struct d_cond_qp_arg *cond_arg);
 //
 void d_cond_qp_ws_create(struct d_ocp_qp_dim *ocp_dim, struct d_cond_qp_arg *cond_arg, struct d_cond_qp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_d_cond_qcqp.h
+++ b/include/hpipm_d_cond_qcqp.h
@@ -64,7 +64,7 @@ struct d_cond_qcqp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution equality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -83,7 +83,7 @@ struct d_cond_qcqp_ws
 	struct blasfeo_dmat *tmp_nuM_nxM;
 //	struct blasfeo_dvec *d_qp;
 //	struct blasfeo_dvec *d_mask_qp;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_cond_qcqp.h
+++ b/include/hpipm_d_cond_qcqp.h
@@ -64,7 +64,7 @@ struct d_cond_qcqp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution equality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -83,12 +83,12 @@ struct d_cond_qcqp_ws
 	struct blasfeo_dmat *tmp_nuM_nxM;
 //	struct blasfeo_dvec *d_qp;
 //	struct blasfeo_dvec *d_mask_qp;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 //
-int d_cond_qcqp_arg_memsize();
+hpipm_size_t d_cond_qcqp_arg_memsize();
 //
 void d_cond_qcqp_arg_create(struct d_cond_qcqp_arg *cond_arg, void *mem);
 //
@@ -101,7 +101,7 @@ void d_cond_qcqp_arg_set_cond_last_stage(int cond_last_stage, struct d_cond_qcqp
 //
 void d_cond_qcqp_compute_dim(struct d_ocp_qcqp_dim *ocp_dim, struct d_dense_qcqp_dim *dense_dim);
 //
-int d_cond_qcqp_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, struct d_cond_qcqp_arg *cond_arg);
+hpipm_size_t d_cond_qcqp_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, struct d_cond_qcqp_arg *cond_arg);
 //
 void d_cond_qcqp_ws_create(struct d_ocp_qcqp_dim *ocp_dim, struct d_cond_qcqp_arg *cond_arg, struct d_cond_qcqp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_d_core_qp_ipm.h
+++ b/include/hpipm_d_core_qp_ipm.h
@@ -36,6 +36,8 @@
 #ifndef HPIPM_D_CORE_QP_IPM_
 #define HPIPM_D_CORE_QP_IPM_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -80,13 +82,13 @@ struct d_core_qp_ipm_workspace
 	int nc_mask; // total number of ineq constr after masking
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam also in solution, or only in Gamma computation
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int d_memsize_core_qp_ipm(int nv, int ne, int nc);
+hpipm_size_t d_memsize_core_qp_ipm(int nv, int ne, int nc);
 //
 void d_create_core_qp_ipm(int nv, int ne, int nc, struct d_core_qp_ipm_workspace *workspace, void *mem);
 //

--- a/include/hpipm_d_core_qp_ipm.h
+++ b/include/hpipm_d_core_qp_ipm.h
@@ -82,7 +82,7 @@ struct d_core_qp_ipm_workspace
 	int nc_mask; // total number of ineq constr after masking
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam also in solution, or only in Gamma computation
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_d_dense_qcqp.h
+++ b/include/hpipm_d_dense_qcqp.h
@@ -69,13 +69,13 @@ struct d_dense_qcqp
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
 	int *Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_dense_qcqp_memsize(struct d_dense_qcqp_dim *dim);
+hpipm_size_t d_dense_qcqp_memsize(struct d_dense_qcqp_dim *dim);
 //
 void d_dense_qcqp_create(struct d_dense_qcqp_dim *dim, struct d_dense_qcqp *qp, void *memory);
 

--- a/include/hpipm_d_dense_qcqp.h
+++ b/include/hpipm_d_dense_qcqp.h
@@ -69,7 +69,7 @@ struct d_dense_qcqp
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
 	int *Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_dense_qcqp_dim.h
+++ b/include/hpipm_d_dense_qcqp_dim.h
@@ -56,7 +56,7 @@ struct d_dense_qcqp_dim
 	int nsg; // number of softened general constraints
 	int nsq; // number of softened quadratic constraints
 	int ns;  // number of softened constraints (nsb+nsg+nsq) TODO number of slacks
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qcqp_dim.h
+++ b/include/hpipm_d_dense_qcqp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_DENSE_QCQP_DIM_H_
 #define HPIPM_D_DENSE_QCQP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,13 +56,13 @@ struct d_dense_qcqp_dim
 	int nsg; // number of softened general constraints
 	int nsq; // number of softened quadratic constraints
 	int ns;  // number of softened constraints (nsb+nsg+nsq) TODO number of slacks
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qcqp_dim_memsize();
+hpipm_size_t d_dense_qcqp_dim_memsize();
 //
 void d_dense_qcqp_dim_create(struct d_dense_qcqp_dim *dim, void *memory);
 //

--- a/include/hpipm_d_dense_qcqp_ipm.h
+++ b/include/hpipm_d_dense_qcqp_ipm.h
@@ -84,7 +84,7 @@ struct d_dense_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -99,13 +99,13 @@ struct d_dense_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nv;
 	int iter; // iteration number
 	int status;
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int d_dense_qcqp_ipm_arg_memsize(struct d_dense_qcqp_dim *dim);
+hpipm_size_t d_dense_qcqp_ipm_arg_memsize(struct d_dense_qcqp_dim *dim);
 //
 void d_dense_qcqp_ipm_arg_create(struct d_dense_qcqp_dim *dim, struct d_dense_qcqp_ipm_arg *arg, void *mem);
 //
@@ -150,7 +150,7 @@ void d_dense_qcqp_ipm_arg_set_split_step(int *value, struct d_dense_qcqp_ipm_arg
 void d_dense_qcqp_ipm_arg_set_t_lam_min(int *value, struct d_dense_qcqp_ipm_arg *arg);
 
 //
-int d_dense_qcqp_ipm_ws_memsize(struct d_dense_qcqp_dim *qp_dim, struct d_dense_qcqp_ipm_arg *arg);
+hpipm_size_t d_dense_qcqp_ipm_ws_memsize(struct d_dense_qcqp_dim *qp_dim, struct d_dense_qcqp_ipm_arg *arg);
 //
 void d_dense_qcqp_ipm_ws_create(struct d_dense_qcqp_dim *qp_dim, struct d_dense_qcqp_ipm_arg *arg, struct d_dense_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_dense_qcqp_ipm.h
+++ b/include/hpipm_d_dense_qcqp_ipm.h
@@ -84,7 +84,7 @@ struct d_dense_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -99,7 +99,7 @@ struct d_dense_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nv;
 	int iter; // iteration number
 	int status;
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_d_dense_qcqp_res.h
+++ b/include/hpipm_d_dense_qcqp_res.h
@@ -62,7 +62,7 @@ struct d_dense_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // infinity norm of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -76,17 +76,17 @@ struct d_dense_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qcqp_res_memsize(struct d_dense_qcqp_dim *dim);
+hpipm_size_t d_dense_qcqp_res_memsize(struct d_dense_qcqp_dim *dim);
 //
 void d_dense_qcqp_res_create(struct d_dense_qcqp_dim *dim, struct d_dense_qcqp_res *res, void *mem);
 //
-int d_dense_qcqp_res_ws_memsize(struct d_dense_qcqp_dim *dim);
+hpipm_size_t d_dense_qcqp_res_ws_memsize(struct d_dense_qcqp_dim *dim);
 //
 void d_dense_qcqp_res_ws_create(struct d_dense_qcqp_dim *dim, struct d_dense_qcqp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_d_dense_qcqp_res.h
+++ b/include/hpipm_d_dense_qcqp_res.h
@@ -62,7 +62,7 @@ struct d_dense_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // infinity norm of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -76,7 +76,7 @@ struct d_dense_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qcqp_sol.h
+++ b/include/hpipm_d_dense_qcqp_sol.h
@@ -61,13 +61,13 @@ struct d_dense_qcqp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qcqp_sol_memsize(struct d_dense_qcqp_dim *dim);
+hpipm_size_t d_dense_qcqp_sol_memsize(struct d_dense_qcqp_dim *dim);
 //
 void d_dense_qcqp_sol_create(struct d_dense_qcqp_dim *dim, struct d_dense_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_d_dense_qcqp_sol.h
+++ b/include/hpipm_d_dense_qcqp_sol.h
@@ -61,7 +61,7 @@ struct d_dense_qcqp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qp.h
+++ b/include/hpipm_d_dense_qp.h
@@ -67,13 +67,13 @@ struct d_dense_qp
 	struct blasfeo_dvec *Z; // (diagonal) hessian of slacks
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_dense_qp_memsize(struct d_dense_qp_dim *dim);
+hpipm_size_t d_dense_qp_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_create(struct d_dense_qp_dim *dim, struct d_dense_qp *qp, void *memory);
 

--- a/include/hpipm_d_dense_qp.h
+++ b/include/hpipm_d_dense_qp.h
@@ -67,7 +67,7 @@ struct d_dense_qp
 	struct blasfeo_dvec *Z; // (diagonal) hessian of slacks
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_dense_qp_dim.h
+++ b/include/hpipm_d_dense_qp_dim.h
@@ -53,7 +53,7 @@ struct d_dense_qp_dim
 	int nsb; // number of softened box constraints
 	int nsg; // number of softened general constraints
 	int ns;  // number of softened constraints (nsb+nsg)
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qp_dim.h
+++ b/include/hpipm_d_dense_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_DENSE_QP_DIM_H_
 #define HPIPM_D_DENSE_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,13 +53,13 @@ struct d_dense_qp_dim
 	int nsb; // number of softened box constraints
 	int nsg; // number of softened general constraints
 	int ns;  // number of softened constraints (nsb+nsg)
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qp_dim_memsize();
+hpipm_size_t d_dense_qp_dim_memsize();
 //
 void d_dense_qp_dim_create(struct d_dense_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_d_dense_qp_ipm.h
+++ b/include/hpipm_d_dense_qp_ipm.h
@@ -88,7 +88,7 @@ struct d_dense_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -154,7 +154,7 @@ struct d_dense_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int ne_li; // number of linearly independent equality constraints
 	int ne_bkp; // ne backup
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_d_dense_qp_ipm.h
+++ b/include/hpipm_d_dense_qp_ipm.h
@@ -88,7 +88,7 @@ struct d_dense_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -154,13 +154,13 @@ struct d_dense_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int ne_li; // number of linearly independent equality constraints
 	int ne_bkp; // ne backup
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int d_dense_qp_ipm_arg_memsize(struct d_dense_qp_dim *dim);
+hpipm_size_t d_dense_qp_ipm_arg_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_ipm_arg_create(struct d_dense_qp_dim *dim, struct d_dense_qp_ipm_arg *arg, void *mem);
 //
@@ -214,7 +214,7 @@ void d_dense_qp_ipm_arg_set_t_lam_min(int *value, struct d_dense_qp_ipm_arg *arg
 void d_dense_qp_ipm_arg_set_split_step(int *value, struct d_dense_qp_ipm_arg *arg);
 
 //
-int d_dense_qp_ipm_ws_memsize(struct d_dense_qp_dim *qp_dim, struct d_dense_qp_ipm_arg *arg);
+hpipm_size_t d_dense_qp_ipm_ws_memsize(struct d_dense_qp_dim *qp_dim, struct d_dense_qp_ipm_arg *arg);
 //
 void d_dense_qp_ipm_ws_create(struct d_dense_qp_dim *qp_dim, struct d_dense_qp_ipm_arg *arg, struct d_dense_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_dense_qp_res.h
+++ b/include/hpipm_d_dense_qp_res.h
@@ -62,7 +62,7 @@ struct d_dense_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -71,7 +71,7 @@ struct d_dense_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbg; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_ns; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qp_res.h
+++ b/include/hpipm_d_dense_qp_res.h
@@ -62,7 +62,7 @@ struct d_dense_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -71,17 +71,17 @@ struct d_dense_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbg; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_ns; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qp_res_memsize(struct d_dense_qp_dim *dim);
+hpipm_size_t d_dense_qp_res_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_res_create(struct d_dense_qp_dim *dim, struct d_dense_qp_res *res, void *mem);
 //
-int d_dense_qp_res_ws_memsize(struct d_dense_qp_dim *dim);
+hpipm_size_t d_dense_qp_res_ws_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_res_ws_create(struct d_dense_qp_dim *dim, struct d_dense_qp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_d_dense_qp_sol.h
+++ b/include/hpipm_d_dense_qp_sol.h
@@ -63,7 +63,7 @@ struct d_dense_qp_sol
 	void *misc;
 	double obj;
 	int valid_obj;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_dense_qp_sol.h
+++ b/include/hpipm_d_dense_qp_sol.h
@@ -63,13 +63,13 @@ struct d_dense_qp_sol
 	void *misc;
 	double obj;
 	int valid_obj;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_dense_qp_sol_memsize(struct d_dense_qp_dim *dim);
+hpipm_size_t d_dense_qp_sol_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_sol_create(struct d_dense_qp_dim *dim, struct d_dense_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_d_ocp_qcqp.h
+++ b/include/hpipm_d_ocp_qcqp.h
@@ -67,7 +67,7 @@ struct d_ocp_qcqp
 	int **idxb; // index of box constraints
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_ocp_qcqp.h
+++ b/include/hpipm_d_ocp_qcqp.h
@@ -67,15 +67,15 @@ struct d_ocp_qcqp
 	int **idxb; // index of box constraints
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_ocp_qcqp_strsize();
+hpipm_size_t d_ocp_qcqp_strsize();
 //
-int d_ocp_qcqp_memsize(struct d_ocp_qcqp_dim *dim);
+hpipm_size_t d_ocp_qcqp_memsize(struct d_ocp_qcqp_dim *dim);
 //
 void d_ocp_qcqp_create(struct d_ocp_qcqp_dim *dim, struct d_ocp_qcqp *qp, void *memory);
 //

--- a/include/hpipm_d_ocp_qcqp_dim.h
+++ b/include/hpipm_d_ocp_qcqp_dim.h
@@ -60,7 +60,7 @@ struct d_ocp_qcqp_dim
 	int *nsg; // number of (two-sided) soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int N; // horizon length
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qcqp_dim.h
+++ b/include/hpipm_d_ocp_qcqp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_OCP_QCQP_DIM_H_
 #define HPIPM_D_OCP_QCQP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +60,15 @@ struct d_ocp_qcqp_dim
 	int *nsg; // number of (two-sided) soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int N; // horizon length
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qcqp_dim_strsize();
+hpipm_size_t d_ocp_qcqp_dim_strsize();
 //
-int d_ocp_qcqp_dim_memsize(int N);
+hpipm_size_t d_ocp_qcqp_dim_memsize(int N);
 //
 void d_ocp_qcqp_dim_create(int N, struct d_ocp_qcqp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_d_ocp_qcqp_ipm.h
+++ b/include/hpipm_d_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct d_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -98,7 +98,7 @@ struct d_ocp_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qcqp_ipm.h
+++ b/include/hpipm_d_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct d_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -98,15 +98,15 @@ struct d_ocp_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qcqp_ipm_arg_strseize();
+hpipm_size_t d_ocp_qcqp_ipm_arg_strsize();
 //
-int d_ocp_qcqp_ipm_arg_memsize(struct d_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_ocp_qcqp_ipm_arg_memsize(struct d_ocp_qcqp_dim *ocp_dim);
 //
 void d_ocp_qcqp_ipm_arg_create(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_ipm_arg *arg, void *mem);
 //
@@ -151,9 +151,9 @@ void d_ocp_qcqp_ipm_arg_set_split_step(int *value, struct d_ocp_qcqp_ipm_arg *ar
 void d_ocp_qcqp_ipm_arg_set_t_lam_min(int *value, struct d_ocp_qcqp_ipm_arg *arg);
 
 //
-int d_ocp_qcqp_ipm_ws_strsize();
+hpipm_size_t d_ocp_qcqp_ipm_ws_strsize();
 //
-int d_ocp_qcqp_ipm_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_ipm_arg *arg);
+hpipm_size_t d_ocp_qcqp_ipm_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_ipm_arg *arg);
 //
 void d_ocp_qcqp_ipm_ws_create(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_ipm_arg *arg, struct d_ocp_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_ocp_qcqp_res.h
+++ b/include/hpipm_d_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct d_ocp_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -77,7 +77,7 @@ struct d_ocp_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qcqp_res.h
+++ b/include/hpipm_d_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct d_ocp_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -77,17 +77,17 @@ struct d_ocp_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qcqp_res_memsize(struct d_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_ocp_qcqp_res_memsize(struct d_ocp_qcqp_dim *ocp_dim);
 //
 void d_ocp_qcqp_res_create(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_res *res, void *mem);
 //
-int d_ocp_qcqp_res_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_ocp_qcqp_res_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim);
 //
 void d_ocp_qcqp_res_ws_create(struct d_ocp_qcqp_dim *ocp_dim, struct d_ocp_qcqp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_d_ocp_qcqp_sol.h
+++ b/include/hpipm_d_ocp_qcqp_sol.h
@@ -58,7 +58,7 @@ struct d_ocp_qcqp_sol
 	struct blasfeo_dvec *pi;
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_ocp_qcqp_sol.h
+++ b/include/hpipm_d_ocp_qcqp_sol.h
@@ -58,15 +58,15 @@ struct d_ocp_qcqp_sol
 	struct blasfeo_dvec *pi;
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_ocp_qcqp_sol_strsize();
+hpipm_size_t d_ocp_qcqp_sol_strsize();
 //
-int d_ocp_qcqp_sol_memsize(struct d_ocp_qcqp_dim *dim);
+hpipm_size_t d_ocp_qcqp_sol_memsize(struct d_ocp_qcqp_dim *dim);
 //
 void d_ocp_qcqp_sol_create(struct d_ocp_qcqp_dim *dim, struct d_ocp_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_d_ocp_qp.h
+++ b/include/hpipm_d_ocp_qp.h
@@ -67,7 +67,7 @@ struct d_ocp_qp
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **idxe; // index of equality constraints
 	int *diag_H_flag; // flag the fact that Hessian is diagonal
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_ocp_qp.h
+++ b/include/hpipm_d_ocp_qp.h
@@ -67,15 +67,15 @@ struct d_ocp_qp
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **idxe; // index of equality constraints
 	int *diag_H_flag; // flag the fact that Hessian is diagonal
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_ocp_qp_strsize();
+hpipm_size_t d_ocp_qp_strsize();
 //
-int d_ocp_qp_memsize(struct d_ocp_qp_dim *dim);
+hpipm_size_t d_ocp_qp_memsize(struct d_ocp_qp_dim *dim);
 //
 void d_ocp_qp_create(struct d_ocp_qp_dim *dim, struct d_ocp_qp *qp, void *memory);
 //

--- a/include/hpipm_d_ocp_qp_dim.h
+++ b/include/hpipm_d_ocp_qp_dim.h
@@ -60,7 +60,7 @@ struct d_ocp_qp_dim
 	int *nbue; // number of input box constraints which are equality
 	int *nge; // number of general constraints which are equality
 	int N; // horizon length
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qp_dim.h
+++ b/include/hpipm_d_ocp_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_OCP_QP_DIM_H_
 #define HPIPM_D_OCP_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +60,15 @@ struct d_ocp_qp_dim
 	int *nbue; // number of input box constraints which are equality
 	int *nge; // number of general constraints which are equality
 	int N; // horizon length
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qp_dim_strsize();
+hpipm_size_t d_ocp_qp_dim_strsize();
 //
-int d_ocp_qp_dim_memsize(int N);
+hpipm_size_t d_ocp_qp_dim_memsize(int N);
 //
 void d_ocp_qp_dim_create(int N, struct d_ocp_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_d_ocp_qp_ipm.h
+++ b/include/hpipm_d_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct d_ocp_qp_ipm_arg
 	int var_init_scheme; // variables initialization scheme
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -130,7 +130,7 @@ struct d_ocp_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int valid_ric_vec; // meaningful riccati vectors
 	int valid_ric_p; // form of riccati p: 0 p*inv(L), 1 p
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qp_ipm.h
+++ b/include/hpipm_d_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct d_ocp_qp_ipm_arg
 	int var_init_scheme; // variables initialization scheme
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -130,15 +130,15 @@ struct d_ocp_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int valid_ric_vec; // meaningful riccati vectors
 	int valid_ric_p; // form of riccati p: 0 p*inv(L), 1 p
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qp_ipm_arg_strseize();
+hpipm_size_t d_ocp_qp_ipm_arg_strsize();
 //
-int d_ocp_qp_ipm_arg_memsize(struct d_ocp_qp_dim *ocp_dim);
+hpipm_size_t d_ocp_qp_ipm_arg_memsize(struct d_ocp_qp_dim *ocp_dim);
 //
 void d_ocp_qp_ipm_arg_create(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_ipm_arg *arg, void *mem);
 //
@@ -189,9 +189,9 @@ void d_ocp_qp_ipm_arg_set_var_init_scheme(int *value, struct d_ocp_qp_ipm_arg *a
 void d_ocp_qp_ipm_arg_set_t_lam_min(int *value, struct d_ocp_qp_ipm_arg *arg);
 
 //
-int d_ocp_qp_ipm_ws_strsize();
+hpipm_size_t d_ocp_qp_ipm_ws_strsize();
 //
-int d_ocp_qp_ipm_ws_memsize(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_ipm_arg *arg);
+hpipm_size_t d_ocp_qp_ipm_ws_memsize(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_ipm_arg *arg);
 //
 void d_ocp_qp_ipm_ws_create(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_ipm_arg *arg, struct d_ocp_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_ocp_qp_red.h
+++ b/include/hpipm_d_ocp_qp_red.h
@@ -61,7 +61,7 @@ struct d_ocp_qp_reduce_eq_dof_arg
 	int comp_prim_sol; // primal solution (v)
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -72,7 +72,7 @@ struct d_ocp_qp_reduce_eq_dof_ws
 	struct blasfeo_dvec *tmp_nbgM;
 	int *e_imask_ux;
 	int *e_imask_d;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -80,7 +80,7 @@ struct d_ocp_qp_reduce_eq_dof_ws
 //
 void d_ocp_qp_dim_reduce_eq_dof(struct d_ocp_qp_dim *dim, struct d_ocp_qp_dim *dim_red);
 //
-int d_ocp_qp_reduce_eq_dof_arg_memsize();
+hpipm_size_t d_ocp_qp_reduce_eq_dof_arg_memsize();
 //
 void d_ocp_qp_reduce_eq_dof_arg_create(struct d_ocp_qp_reduce_eq_dof_arg *arg, void *mem);
 //
@@ -94,7 +94,7 @@ void d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_eq(struct d_ocp_qp_reduce_eq_d
 //
 void d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_ineq(struct d_ocp_qp_reduce_eq_dof_arg *arg, int value);
 //
-int d_ocp_qp_reduce_eq_dof_ws_memsize(struct d_ocp_qp_dim *dim);
+hpipm_size_t d_ocp_qp_reduce_eq_dof_ws_memsize(struct d_ocp_qp_dim *dim);
 //
 void d_ocp_qp_reduce_eq_dof_ws_create(struct d_ocp_qp_dim *dim, struct d_ocp_qp_reduce_eq_dof_ws *work, void *mem);
 //

--- a/include/hpipm_d_ocp_qp_red.h
+++ b/include/hpipm_d_ocp_qp_red.h
@@ -61,7 +61,7 @@ struct d_ocp_qp_reduce_eq_dof_arg
 	int comp_prim_sol; // primal solution (v)
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -72,7 +72,7 @@ struct d_ocp_qp_reduce_eq_dof_ws
 	struct blasfeo_dvec *tmp_nbgM;
 	int *e_imask_ux;
 	int *e_imask_d;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_ocp_qp_res.h
+++ b/include/hpipm_d_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct d_ocp_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -72,7 +72,7 @@ struct d_ocp_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_nsM; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_ocp_qp_res.h
+++ b/include/hpipm_d_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct d_ocp_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -72,17 +72,17 @@ struct d_ocp_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_nsM; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_ocp_qp_res_memsize(struct d_ocp_qp_dim *ocp_dim);
+hpipm_size_t d_ocp_qp_res_memsize(struct d_ocp_qp_dim *ocp_dim);
 //
 void d_ocp_qp_res_create(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_res *res, void *mem);
 //
-int d_ocp_qp_res_ws_memsize(struct d_ocp_qp_dim *ocp_dim);
+hpipm_size_t d_ocp_qp_res_ws_memsize(struct d_ocp_qp_dim *ocp_dim);
 //
 void d_ocp_qp_res_ws_create(struct d_ocp_qp_dim *ocp_dim, struct d_ocp_qp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_d_ocp_qp_sol.h
+++ b/include/hpipm_d_ocp_qp_sol.h
@@ -59,15 +59,15 @@ struct d_ocp_qp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_ocp_qp_sol_strsize();
+hpipm_size_t d_ocp_qp_sol_strsize();
 //
-int d_ocp_qp_sol_memsize(struct d_ocp_qp_dim *dim);
+hpipm_size_t d_ocp_qp_sol_memsize(struct d_ocp_qp_dim *dim);
 //
 void d_ocp_qp_sol_create(struct d_ocp_qp_dim *dim, struct d_ocp_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_d_ocp_qp_sol.h
+++ b/include/hpipm_d_ocp_qp_sol.h
@@ -59,7 +59,7 @@ struct d_ocp_qp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_part_cond.h
+++ b/include/hpipm_d_part_cond.h
@@ -43,6 +43,7 @@
 #include <blasfeo_target.h>
 #include <blasfeo_common.h>
 
+#include "hpipm_common.h"
 #include "hpipm_d_cond.h"
 
 
@@ -56,7 +57,7 @@ struct d_part_cond_qp_arg
 	{
 	struct d_cond_qp_arg *cond_arg;
 	int N2;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -64,13 +65,13 @@ struct d_part_cond_qp_arg
 struct d_part_cond_qp_ws
 	{
 	struct d_cond_qp_ws *cond_workspace;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_part_cond_qp_arg_memsize(int N2);
+hpipm_size_t d_part_cond_qp_arg_memsize(int N2);
 //
 void d_part_cond_qp_arg_create(int N2, struct d_part_cond_qp_arg *cond_arg, void *mem);
 //
@@ -89,7 +90,7 @@ void d_part_cond_qp_compute_block_size(int N, int N2, int *block_size);
 //
 void d_part_cond_qp_compute_dim(struct d_ocp_qp_dim *ocp_dim, int *block_size, struct d_ocp_qp_dim *part_dense_dim);
 //
-int d_part_cond_qp_ws_memsize(struct d_ocp_qp_dim *ocp_dim, int *block_size, struct d_ocp_qp_dim *part_dense_dim, struct d_part_cond_qp_arg *cond_arg);
+hpipm_size_t d_part_cond_qp_ws_memsize(struct d_ocp_qp_dim *ocp_dim, int *block_size, struct d_ocp_qp_dim *part_dense_dim, struct d_part_cond_qp_arg *cond_arg);
 //
 void d_part_cond_qp_ws_create(struct d_ocp_qp_dim *ocp_dim, int *block_size, struct d_ocp_qp_dim *part_dense_dim, struct d_part_cond_qp_arg *cond_arg, struct d_part_cond_qp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_d_part_cond.h
+++ b/include/hpipm_d_part_cond.h
@@ -57,7 +57,7 @@ struct d_part_cond_qp_arg
 	{
 	struct d_cond_qp_arg *cond_arg;
 	int N2;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -65,7 +65,7 @@ struct d_part_cond_qp_arg
 struct d_part_cond_qp_ws
 	{
 	struct d_cond_qp_ws *cond_workspace;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_part_cond_qcqp.h
+++ b/include/hpipm_d_part_cond_qcqp.h
@@ -56,7 +56,7 @@ struct d_part_cond_qcqp_arg
 	{
 	struct d_cond_qcqp_arg *cond_arg;
 	int N2;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -64,7 +64,7 @@ struct d_part_cond_qcqp_arg
 struct d_part_cond_qcqp_ws
 	{
 	struct d_cond_qcqp_ws *cond_ws;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_part_cond_qcqp.h
+++ b/include/hpipm_d_part_cond_qcqp.h
@@ -56,7 +56,7 @@ struct d_part_cond_qcqp_arg
 	{
 	struct d_cond_qcqp_arg *cond_arg;
 	int N2;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -64,13 +64,13 @@ struct d_part_cond_qcqp_arg
 struct d_part_cond_qcqp_ws
 	{
 	struct d_cond_qcqp_ws *cond_ws;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_part_cond_qcqp_arg_memsize(int N2);
+hpipm_size_t d_part_cond_qcqp_arg_memsize(int N2);
 //
 void d_part_cond_qcqp_arg_create(int N2, struct d_part_cond_qcqp_arg *cond_arg, void *mem);
 //
@@ -83,7 +83,7 @@ void d_part_cond_qcqp_compute_block_size(int N, int N2, int *block_size);
 //
 void d_part_cond_qcqp_compute_dim(struct d_ocp_qcqp_dim *ocp_dim, int *block_size, struct d_ocp_qcqp_dim *part_dense_dim);
 //
-int d_part_cond_qcqp_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, int *block_size, struct d_ocp_qcqp_dim *part_dense_dim, struct d_part_cond_qcqp_arg *cond_arg);
+hpipm_size_t d_part_cond_qcqp_ws_memsize(struct d_ocp_qcqp_dim *ocp_dim, int *block_size, struct d_ocp_qcqp_dim *part_dense_dim, struct d_part_cond_qcqp_arg *cond_arg);
 //
 void d_part_cond_qcqp_ws_create(struct d_ocp_qcqp_dim *ocp_dim, int *block_size, struct d_ocp_qcqp_dim *part_dense_dim, struct d_part_cond_qcqp_arg *cond_arg, struct d_part_cond_qcqp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_d_sim_erk.h
+++ b/include/hpipm_d_sim_erk.h
@@ -36,6 +36,8 @@
 #ifndef HPIPM_D_SIM_ERK_H_
 #define HPIPM_D_SIM_ERK_H_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,7 +49,7 @@ struct d_sim_erk_arg
 	int steps; // number of steps
 //	int for_sens; // compute adjoint sensitivities
 //	int adj_sens; // compute adjoint sensitivities
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -73,20 +75,20 @@ struct d_sim_erk_ws
 	int na; // number of adjoint sensitivities
 	int nf_max; // max number of forward sensitivities
 	int na_max; // max number of adjoint sensitivities
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_sim_erk_arg_memsize();
+hpipm_size_t d_sim_erk_arg_memsize();
 //
 void d_sim_erk_arg_create(struct d_sim_erk_arg *erk_arg, void *mem);
 //
 void d_sim_erk_arg_set_all(struct d_sim_rk_data *rk_data, double h, int steps, struct d_sim_erk_arg *erk_arg);
 
 //
-int d_sim_erk_ws_memsize(struct d_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max);
+hpipm_size_t d_sim_erk_ws_memsize(struct d_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max);
 //
 void d_sim_erk_ws_create(struct d_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max, struct d_sim_erk_ws *work, void *memory);
 //

--- a/include/hpipm_d_sim_erk.h
+++ b/include/hpipm_d_sim_erk.h
@@ -49,7 +49,7 @@ struct d_sim_erk_arg
 	int steps; // number of steps
 //	int for_sens; // compute adjoint sensitivities
 //	int adj_sens; // compute adjoint sensitivities
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -75,7 +75,7 @@ struct d_sim_erk_ws
 	int na; // number of adjoint sensitivities
 	int nf_max; // max number of forward sensitivities
 	int na_max; // max number of adjoint sensitivities
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_sim_rk.h
+++ b/include/hpipm_d_sim_rk.h
@@ -36,6 +36,8 @@
 #ifndef HPIPM_D_SIM_RK_H_
 #define HPIPM_D_SIM_RK_H_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,13 +49,13 @@ struct d_sim_rk_data
 	double *C_rk; // c in butcher tableau
 	int expl; // erk vs irk
 	int ns; // number of stages
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_sim_rk_data_memsize(int ns);
+hpipm_size_t d_sim_rk_data_memsize(int ns);
 //
 void d_sim_rk_data_create(int ns, struct d_sim_rk_data *rk_data, void *memory);
 //

--- a/include/hpipm_d_sim_rk.h
+++ b/include/hpipm_d_sim_rk.h
@@ -49,7 +49,7 @@ struct d_sim_rk_data
 	double *C_rk; // c in butcher tableau
 	int expl; // erk vs irk
 	int ns; // number of stages
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp.h
+++ b/include/hpipm_d_tree_ocp_qcqp.h
@@ -41,6 +41,7 @@
 #include <blasfeo_target.h>
 #include <blasfeo_common.h>
 
+#include "hpipm_common.h"
 #include "hpipm_d_tree_ocp_qcqp_dim.h"
 
 
@@ -66,13 +67,13 @@ struct d_tree_ocp_qcqp
 	struct blasfeo_dvec *Z; // Nn
 	int **idxb; // index of box constraints // Nn
 	int **idxs_rev; // index of soft constraints
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_tree_ocp_qcqp_memsize(struct d_tree_ocp_qcqp_dim *dim);
+hpipm_size_t d_tree_ocp_qcqp_memsize(struct d_tree_ocp_qcqp_dim *dim);
 //
 void d_tree_ocp_qcqp_create(struct d_tree_ocp_qcqp_dim *dim, struct d_tree_ocp_qcqp *qp, void *memory);
 //

--- a/include/hpipm_d_tree_ocp_qcqp.h
+++ b/include/hpipm_d_tree_ocp_qcqp.h
@@ -67,7 +67,7 @@ struct d_tree_ocp_qcqp
 	struct blasfeo_dvec *Z; // Nn
 	int **idxb; // index of box constraints // Nn
 	int **idxs_rev; // index of soft constraints
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp_dim.h
+++ b/include/hpipm_d_tree_ocp_qcqp_dim.h
@@ -61,7 +61,7 @@ struct d_tree_ocp_qcqp_dim
 	int *nsg; // number of soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int Nn; // number of nodes
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp_dim.h
+++ b/include/hpipm_d_tree_ocp_qcqp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_TREE_OCP_QCQP_DIM_H_
 #define HPIPM_D_TREE_OCP_QCQP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,15 +61,15 @@ struct d_tree_ocp_qcqp_dim
 	int *nsg; // number of soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int Nn; // number of nodes
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qcqp_dim_strsize();
+hpipm_size_t d_tree_ocp_qcqp_dim_strsize();
 //
-int d_tree_ocp_qcqp_dim_memsize(int Nn);
+hpipm_size_t d_tree_ocp_qcqp_dim_memsize(int Nn);
 //
 void d_tree_ocp_qcqp_dim_create(int Nn, struct d_tree_ocp_qcqp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_d_tree_ocp_qcqp_ipm.h
+++ b/include/hpipm_d_tree_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct d_tree_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -98,7 +98,7 @@ struct d_tree_ocp_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp_ipm.h
+++ b/include/hpipm_d_tree_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct d_tree_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -98,15 +98,15 @@ struct d_tree_ocp_qcqp_ipm_ws
 	struct blasfeo_dvec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qcqp_ipm_arg_strseize();
+hpipm_size_t d_tree_ocp_qcqp_ipm_arg_strsize();
 //
-int d_tree_ocp_qcqp_ipm_arg_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_tree_ocp_qcqp_ipm_arg_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
 //
 void d_tree_ocp_qcqp_ipm_arg_create(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_ipm_arg *arg, void *mem);
 //
@@ -151,9 +151,9 @@ void d_tree_ocp_qcqp_ipm_arg_set_split_step(int *value, struct d_tree_ocp_qcqp_i
 void d_tree_ocp_qcqp_ipm_arg_set_t_lam_min(int *value, struct d_tree_ocp_qcqp_ipm_arg *arg);
 
 //
-int d_tree_ocp_qcqp_ipm_ws_strsize();
+hpipm_size_t d_tree_ocp_qcqp_ipm_ws_strsize();
 //
-int d_tree_ocp_qcqp_ipm_ws_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_ipm_arg *arg);
+hpipm_size_t d_tree_ocp_qcqp_ipm_ws_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_ipm_arg *arg);
 //
 void d_tree_ocp_qcqp_ipm_ws_create(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_ipm_arg *arg, struct d_tree_ocp_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_tree_ocp_qcqp_res.h
+++ b/include/hpipm_d_tree_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct d_tree_ocp_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -77,7 +77,7 @@ struct d_tree_ocp_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp_res.h
+++ b/include/hpipm_d_tree_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct d_tree_ocp_qcqp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -77,17 +77,17 @@ struct d_tree_ocp_qcqp_res_ws
 	struct blasfeo_dvec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qcqp_res_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_tree_ocp_qcqp_res_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
 //
 void d_tree_ocp_qcqp_res_create(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_res *res, void *mem);
 //
-int d_tree_ocp_qcqp_res_ws_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t d_tree_ocp_qcqp_res_ws_memsize(struct d_tree_ocp_qcqp_dim *ocp_dim);
 //
 void d_tree_ocp_qcqp_res_ws_create(struct d_tree_ocp_qcqp_dim *ocp_dim, struct d_tree_ocp_qcqp_res_ws *ws, void *mem);
 //

--- a/include/hpipm_d_tree_ocp_qcqp_sol.h
+++ b/include/hpipm_d_tree_ocp_qcqp_sol.h
@@ -57,7 +57,7 @@ struct d_tree_ocp_qcqp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qcqp_sol.h
+++ b/include/hpipm_d_tree_ocp_qcqp_sol.h
@@ -57,13 +57,13 @@ struct d_tree_ocp_qcqp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_tree_ocp_qcqp_sol_memsize(struct d_tree_ocp_qcqp_dim *dim);
+hpipm_size_t d_tree_ocp_qcqp_sol_memsize(struct d_tree_ocp_qcqp_dim *dim);
 //
 void d_tree_ocp_qcqp_sol_create(struct d_tree_ocp_qcqp_dim *dim, struct d_tree_ocp_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_d_tree_ocp_qp.h
+++ b/include/hpipm_d_tree_ocp_qp.h
@@ -66,7 +66,7 @@ struct d_tree_ocp_qp
 	int **idxb; // index of box constraints // Nn
 //	int **idxs; // index of soft constraints
 	int **idxs_rev; // index of soft constraints
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qp.h
+++ b/include/hpipm_d_tree_ocp_qp.h
@@ -66,13 +66,13 @@ struct d_tree_ocp_qp
 	int **idxb; // index of box constraints // Nn
 //	int **idxs; // index of soft constraints
 	int **idxs_rev; // index of soft constraints
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_tree_ocp_qp_memsize(struct d_tree_ocp_qp_dim *dim);
+hpipm_size_t d_tree_ocp_qp_memsize(struct d_tree_ocp_qp_dim *dim);
 //
 void d_tree_ocp_qp_create(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp *qp, void *memory);
 //

--- a/include/hpipm_d_tree_ocp_qp_dim.h
+++ b/include/hpipm_d_tree_ocp_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_D_TREE_OCP_QP_DIM_H_
 #define HPIPM_D_TREE_OCP_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,15 +58,15 @@ struct d_tree_ocp_qp_dim
 	int *nsbu; // number of soft input box constraints
 	int *nsg; // number of soft general constraints
 	int Nn; // number of nodes
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qp_dim_strsize();
+hpipm_size_t d_tree_ocp_qp_dim_strsize();
 //
-int d_tree_ocp_qp_dim_memsize(int Nn);
+hpipm_size_t d_tree_ocp_qp_dim_memsize(int Nn);
 //
 void d_tree_ocp_qp_dim_create(int Nn, struct d_tree_ocp_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_d_tree_ocp_qp_dim.h
+++ b/include/hpipm_d_tree_ocp_qp_dim.h
@@ -58,7 +58,7 @@ struct d_tree_ocp_qp_dim
 	int *nsbu; // number of soft input box constraints
 	int *nsg; // number of soft general constraints
 	int Nn; // number of nodes
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qp_ipm.h
+++ b/include/hpipm_d_tree_ocp_qp_ipm.h
@@ -83,7 +83,7 @@ struct d_tree_ocp_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -121,13 +121,13 @@ struct d_tree_ocp_qp_ipm_ws
 	int status; // solver status
 	int lq_fact; // cache from arg
 	int mask_constr; // use constr mask
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qp_ipm_arg_memsize(struct d_tree_ocp_qp_dim *dim);
+hpipm_size_t d_tree_ocp_qp_ipm_arg_memsize(struct d_tree_ocp_qp_dim *dim);
 //
 void d_tree_ocp_qp_ipm_arg_create(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp_ipm_arg *arg, void *mem);
 //
@@ -170,7 +170,7 @@ void d_tree_ocp_qp_ipm_arg_set_split_step(int *value, struct d_tree_ocp_qp_ipm_a
 void d_tree_ocp_qp_ipm_arg_set_t_lam_min(int *value, struct d_tree_ocp_qp_ipm_arg *arg);
 
 //
-int d_tree_ocp_qp_ipm_ws_memsize(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp_ipm_arg *arg);
+hpipm_size_t d_tree_ocp_qp_ipm_ws_memsize(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp_ipm_arg *arg);
 //
 void d_tree_ocp_qp_ipm_ws_create(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp_ipm_arg *arg, struct d_tree_ocp_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_d_tree_ocp_qp_ipm.h
+++ b/include/hpipm_d_tree_ocp_qp_ipm.h
@@ -83,7 +83,7 @@ struct d_tree_ocp_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -121,7 +121,7 @@ struct d_tree_ocp_qp_ipm_ws
 	int status; // solver status
 	int lq_fact; // cache from arg
 	int mask_constr; // use constr mask
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qp_res.h
+++ b/include/hpipm_d_tree_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct d_tree_ocp_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -72,17 +72,17 @@ struct d_tree_ocp_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_nsM; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int d_tree_ocp_qp_res_memsize(struct d_tree_ocp_qp_dim *ocp_dim);
+hpipm_size_t d_tree_ocp_qp_res_memsize(struct d_tree_ocp_qp_dim *ocp_dim);
 //
 void d_tree_ocp_qp_res_create(struct d_tree_ocp_qp_dim *ocp_dim, struct d_tree_ocp_qp_res *res, void *mem);
 //
-int d_tree_ocp_qp_res_ws_memsize(struct d_tree_ocp_qp_dim *ocp_dim);
+hpipm_size_t d_tree_ocp_qp_res_ws_memsize(struct d_tree_ocp_qp_dim *ocp_dim);
 //
 void d_tree_ocp_qp_res_ws_create(struct d_tree_ocp_qp_dim *ocp_dim, struct d_tree_ocp_qp_res_ws *ws, void *mem);
 //

--- a/include/hpipm_d_tree_ocp_qp_res.h
+++ b/include/hpipm_d_tree_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct d_tree_ocp_qp_res
 	struct blasfeo_dvec *res_m; // m-residuals
 	double res_max[4]; // max of residuals
 	double res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -72,7 +72,7 @@ struct d_tree_ocp_qp_res_ws
 	{
 	struct blasfeo_dvec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_dvec *tmp_nsM; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qp_sol.h
+++ b/include/hpipm_d_tree_ocp_qp_sol.h
@@ -57,7 +57,7 @@ struct d_tree_ocp_qp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_d_tree_ocp_qp_sol.h
+++ b/include/hpipm_d_tree_ocp_qp_sol.h
@@ -57,13 +57,13 @@ struct d_tree_ocp_qp_sol
 	struct blasfeo_dvec *lam;
 	struct blasfeo_dvec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int d_tree_ocp_qp_sol_memsize(struct d_tree_ocp_qp_dim *dim);
+hpipm_size_t d_tree_ocp_qp_sol_memsize(struct d_tree_ocp_qp_dim *dim);
 //
 void d_tree_ocp_qp_sol_create(struct d_tree_ocp_qp_dim *dim, struct d_tree_ocp_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_m_ocp_qp_ipm_hard.h
+++ b/include/hpipm_m_ocp_qp_ipm_hard.h
@@ -102,7 +102,7 @@ struct m_ipm_hard_ocp_qp_arg
 
 
 //
-int m_memsize_ipm_hard_ocp_qp(struct d_ocp_qp *d_qp, struct s_ocp_qp *s_qp, struct m_ipm_hard_ocp_qp_arg *arg);
+hpipm_size_t m_memsize_ipm_hard_ocp_qp(struct d_ocp_qp *d_qp, struct s_ocp_qp *s_qp, struct m_ipm_hard_ocp_qp_arg *arg);
 //
 void m_create_ipm_hard_ocp_qp(struct d_ocp_qp *d_qp, struct s_ocp_qp *s_qp, struct m_ipm_hard_ocp_qp_arg *arg, struct m_ipm_hard_ocp_qp_workspace *ws, void *mem);
 //

--- a/include/hpipm_s_cond.h
+++ b/include/hpipm_s_cond.h
@@ -65,7 +65,7 @@ struct s_cond_qp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -82,13 +82,13 @@ struct s_cond_qp_ws
 	struct blasfeo_svec *tmp_nbgM;
 	struct blasfeo_svec *tmp_nuxM;
 	int bs; // block size
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_cond_qp_arg_memsize();
+hpipm_size_t s_cond_qp_arg_memsize();
 //
 void s_cond_qp_arg_create(struct s_cond_qp_arg *cond_arg, void *mem);
 //
@@ -109,7 +109,7 @@ void s_cond_qp_arg_set_comp_dual_sol_ineq(int value, struct s_cond_qp_arg *cond_
 //
 void s_cond_qp_compute_dim(struct s_ocp_qp_dim *ocp_dim, struct s_dense_qp_dim *dense_dim);
 //
-int s_cond_qp_ws_memsize(struct s_ocp_qp_dim *ocp_dim, struct s_cond_qp_arg *cond_arg);
+hpipm_size_t s_cond_qp_ws_memsize(struct s_ocp_qp_dim *ocp_dim, struct s_cond_qp_arg *cond_arg);
 //
 void s_cond_qp_ws_create(struct s_ocp_qp_dim *ocp_dim, struct s_cond_qp_arg *cond_arg, struct s_cond_qp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_s_cond.h
+++ b/include/hpipm_s_cond.h
@@ -65,7 +65,7 @@ struct s_cond_qp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_cond_qcqp.h
+++ b/include/hpipm_s_cond_qcqp.h
@@ -64,7 +64,7 @@ struct s_cond_qcqp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution equality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -83,7 +83,7 @@ struct s_cond_qcqp_ws
 	struct blasfeo_smat *tmp_nuM_nxM;
 //	struct blasfeo_svec *d_qp;
 //	struct blasfeo_svec *d_mask_qp;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_cond_qcqp.h
+++ b/include/hpipm_s_cond_qcqp.h
@@ -64,7 +64,7 @@ struct s_cond_qcqp_arg
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution equality constr (lam t)
 	int square_root_alg; // square root algorithm (faster but requires RSQ>0)
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -83,12 +83,12 @@ struct s_cond_qcqp_ws
 	struct blasfeo_smat *tmp_nuM_nxM;
 //	struct blasfeo_svec *d_qp;
 //	struct blasfeo_svec *d_mask_qp;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 //
-int s_cond_qcqp_arg_memsize();
+hpipm_size_t s_cond_qcqp_arg_memsize();
 //
 void s_cond_qcqp_arg_create(struct s_cond_qcqp_arg *cond_arg, void *mem);
 //
@@ -101,7 +101,7 @@ void s_cond_qcqp_arg_set_cond_last_stage(int cond_last_stage, struct s_cond_qcqp
 //
 void s_cond_qcqp_compute_dim(struct s_ocp_qcqp_dim *ocp_dim, struct s_dense_qcqp_dim *dense_dim);
 //
-int s_cond_qcqp_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, struct s_cond_qcqp_arg *cond_arg);
+hpipm_size_t s_cond_qcqp_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, struct s_cond_qcqp_arg *cond_arg);
 //
 void s_cond_qcqp_ws_create(struct s_ocp_qcqp_dim *ocp_dim, struct s_cond_qcqp_arg *cond_arg, struct s_cond_qcqp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_s_core_qp_ipm.h
+++ b/include/hpipm_s_core_qp_ipm.h
@@ -82,7 +82,7 @@ struct s_core_qp_ipm_workspace
 	int nc_mask; // total number of ineq constr after masking
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam also in solution, or only in Gamma computation
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_s_core_qp_ipm.h
+++ b/include/hpipm_s_core_qp_ipm.h
@@ -36,6 +36,8 @@
 #ifndef HPIPM_S_CORE_QP_IPM_
 #define HPIPM_S_CORE_QP_IPM_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -80,13 +82,13 @@ struct s_core_qp_ipm_workspace
 	int nc_mask; // total number of ineq constr after masking
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam also in solution, or only in Gamma computation
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int s_memsize_core_qp_ipm(int nv, int ne, int nc);
+hpipm_size_t s_memsize_core_qp_ipm(int nv, int ne, int nc);
 //
 void s_create_core_qp_ipm(int nv, int ne, int nc, struct s_core_qp_ipm_workspace *workspace, void *mem);
 //

--- a/include/hpipm_s_dense_qcqp.h
+++ b/include/hpipm_s_dense_qcqp.h
@@ -69,13 +69,13 @@ struct s_dense_qcqp
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
 	int *Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_dense_qcqp_memsize(struct s_dense_qcqp_dim *dim);
+hpipm_size_t s_dense_qcqp_memsize(struct s_dense_qcqp_dim *dim);
 //
 void s_dense_qcqp_create(struct s_dense_qcqp_dim *dim, struct s_dense_qcqp *qp, void *memory);
 

--- a/include/hpipm_s_dense_qcqp.h
+++ b/include/hpipm_s_dense_qcqp.h
@@ -69,7 +69,7 @@ struct s_dense_qcqp
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
 	int *Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_dense_qcqp_dim.h
+++ b/include/hpipm_s_dense_qcqp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_S_DENSE_QCQP_DIM_H_
 #define HPIPM_S_DENSE_QCQP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,13 +56,13 @@ struct s_dense_qcqp_dim
 	int nsg; // number of softened general constraints
 	int nsq; // number of softened quadratic constraints
 	int ns;  // number of softened constraints (nsb+nsg+nsq) TODO number of slacks
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qcqp_dim_memsize();
+hpipm_size_t s_dense_qcqp_dim_memsize();
 //
 void s_dense_qcqp_dim_create(struct s_dense_qcqp_dim *dim, void *memory);
 //

--- a/include/hpipm_s_dense_qcqp_dim.h
+++ b/include/hpipm_s_dense_qcqp_dim.h
@@ -56,7 +56,7 @@ struct s_dense_qcqp_dim
 	int nsg; // number of softened general constraints
 	int nsq; // number of softened quadratic constraints
 	int ns;  // number of softened constraints (nsb+nsg+nsq) TODO number of slacks
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qcqp_ipm.h
+++ b/include/hpipm_s_dense_qcqp_ipm.h
@@ -84,7 +84,7 @@ struct s_dense_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -107,13 +107,13 @@ struct s_dense_qcqp_ipm_ws
 //	int scale;
 //	int use_hess_fact;
 	int status;
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int s_dense_qcqp_ipm_arg_memsize(struct s_dense_qcqp_dim *dim);
+hpipm_size_t s_dense_qcqp_ipm_arg_memsize(struct s_dense_qcqp_dim *dim);
 //
 void s_dense_qcqp_ipm_arg_create(struct s_dense_qcqp_dim *dim, struct s_dense_qcqp_ipm_arg *arg, void *mem);
 //
@@ -158,7 +158,7 @@ void s_dense_qcqp_ipm_arg_set_split_step(int *value, struct s_dense_qcqp_ipm_arg
 void s_dense_qcqp_ipm_arg_set_t_lam_min(int *value, struct s_dense_qcqp_ipm_arg *arg);
 
 //
-int s_dense_qcqp_ipm_ws_memsize(struct s_dense_qcqp_dim *qp_dim, struct s_dense_qcqp_ipm_arg *arg);
+hpipm_size_t s_dense_qcqp_ipm_ws_memsize(struct s_dense_qcqp_dim *qp_dim, struct s_dense_qcqp_ipm_arg *arg);
 //
 void s_dense_qcqp_ipm_ws_create(struct s_dense_qcqp_dim *qp_dim, struct s_dense_qcqp_ipm_arg *arg, struct s_dense_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_dense_qcqp_ipm.h
+++ b/include/hpipm_s_dense_qcqp_ipm.h
@@ -84,7 +84,7 @@ struct s_dense_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -107,7 +107,7 @@ struct s_dense_qcqp_ipm_ws
 //	int scale;
 //	int use_hess_fact;
 	int status;
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_s_dense_qcqp_res.h
+++ b/include/hpipm_s_dense_qcqp_res.h
@@ -62,7 +62,7 @@ struct s_dense_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // infinity norm of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -76,7 +76,7 @@ struct s_dense_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qcqp_res.h
+++ b/include/hpipm_s_dense_qcqp_res.h
@@ -62,7 +62,7 @@ struct s_dense_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // infinity norm of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -76,17 +76,17 @@ struct s_dense_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qcqp_res_memsize(struct s_dense_qcqp_dim *dim);
+hpipm_size_t s_dense_qcqp_res_memsize(struct s_dense_qcqp_dim *dim);
 //
 void s_dense_qcqp_res_create(struct s_dense_qcqp_dim *dim, struct s_dense_qcqp_res *res, void *mem);
 //
-int s_dense_qcqp_res_ws_memsize(struct s_dense_qcqp_dim *dim);
+hpipm_size_t s_dense_qcqp_res_ws_memsize(struct s_dense_qcqp_dim *dim);
 //
 void s_dense_qcqp_res_ws_create(struct s_dense_qcqp_dim *dim, struct s_dense_qcqp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_s_dense_qcqp_sol.h
+++ b/include/hpipm_s_dense_qcqp_sol.h
@@ -61,7 +61,7 @@ struct s_dense_qcqp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qcqp_sol.h
+++ b/include/hpipm_s_dense_qcqp_sol.h
@@ -61,13 +61,13 @@ struct s_dense_qcqp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qcqp_sol_memsize(struct s_dense_qcqp_dim *dim);
+hpipm_size_t s_dense_qcqp_sol_memsize(struct s_dense_qcqp_dim *dim);
 //
 void s_dense_qcqp_sol_create(struct s_dense_qcqp_dim *dim, struct s_dense_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_dense_qp.h
+++ b/include/hpipm_s_dense_qp.h
@@ -67,13 +67,13 @@ struct s_dense_qp
 	struct blasfeo_svec *Z; // (diagonal) hessian of slacks
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_dense_qp_memsize(struct s_dense_qp_dim *dim);
+hpipm_size_t s_dense_qp_memsize(struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_create(struct s_dense_qp_dim *dim, struct s_dense_qp *qp, void *memory);
 

--- a/include/hpipm_s_dense_qp.h
+++ b/include/hpipm_s_dense_qp.h
@@ -67,7 +67,7 @@ struct s_dense_qp
 	struct blasfeo_svec *Z; // (diagonal) hessian of slacks
 	int *idxb; // index of box constraints
 	int *idxs_rev; // index of soft constraints (reverse storage)
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_dense_qp_dim.h
+++ b/include/hpipm_s_dense_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_S_DENSE_QP_DIM_H_
 #define HPIPM_S_DENSE_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,13 +53,13 @@ struct s_dense_qp_dim
 	int nsb; // number of softened box constraints
 	int nsg; // number of softened general constraints
 	int ns;  // number of softened constraints (nsb+nsg)
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qp_dim_memsize();
+hpipm_size_t s_dense_qp_dim_memsize();
 //
 void s_dense_qp_dim_create(struct s_dense_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_s_dense_qp_dim.h
+++ b/include/hpipm_s_dense_qp_dim.h
@@ -53,7 +53,7 @@ struct s_dense_qp_dim
 	int nsb; // number of softened box constraints
 	int nsg; // number of softened general constraints
 	int ns;  // number of softened constraints (nsb+nsg)
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qp_ipm.h
+++ b/include/hpipm_s_dense_qp_ipm.h
@@ -88,7 +88,7 @@ struct s_dense_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -154,7 +154,7 @@ struct s_dense_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int ne_li; // number of linearly independent equality constraints
 	int ne_bkp; // ne backup
-    hpipm_size_t memsize; // memory size (in bytes) of workspace
+	hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 

--- a/include/hpipm_s_dense_qp_ipm.h
+++ b/include/hpipm_s_dense_qp_ipm.h
@@ -88,7 +88,7 @@ struct s_dense_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -154,13 +154,13 @@ struct s_dense_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int ne_li; // number of linearly independent equality constraints
 	int ne_bkp; // ne backup
-	int memsize; // memory size (in bytes) of workspace
+    hpipm_size_t memsize; // memory size (in bytes) of workspace
 	};
 
 
 
 //
-int s_dense_qp_ipm_arg_memsize(struct s_dense_qp_dim *qp_dim);
+hpipm_size_t s_dense_qp_ipm_arg_memsize(struct s_dense_qp_dim *qp_dim);
 //
 void s_dense_qp_ipm_arg_create(struct s_dense_qp_dim *qp_dim, struct s_dense_qp_ipm_arg *arg, void *mem);
 //
@@ -213,7 +213,7 @@ void s_dense_qp_ipm_arg_set_split_step(int *value, struct s_dense_qp_ipm_arg *ar
 void s_dense_qp_ipm_arg_set_t_lam_min(int *value, struct s_dense_qp_ipm_arg *arg);
 
 //
-int s_dense_qp_ipm_ws_memsize(struct s_dense_qp_dim *qp_dim, struct s_dense_qp_ipm_arg *arg);
+hpipm_size_t s_dense_qp_ipm_ws_memsize(struct s_dense_qp_dim *qp_dim, struct s_dense_qp_ipm_arg *arg);
 //
 void s_dense_qp_ipm_ws_create(struct s_dense_qp_dim *qp_dim, struct s_dense_qp_ipm_arg *arg, struct s_dense_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_dense_qp_res.h
+++ b/include/hpipm_s_dense_qp_res.h
@@ -62,7 +62,7 @@ struct s_dense_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -71,17 +71,17 @@ struct s_dense_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbg; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_ns; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qp_res_memsize(struct s_dense_qp_dim *dim);
+hpipm_size_t s_dense_qp_res_memsize(struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_res_create(struct s_dense_qp_dim *dim, struct s_dense_qp_res *res, void *mem);
 //
-int s_dense_qp_res_ws_memsize(struct s_dense_qp_dim *dim);
+hpipm_size_t s_dense_qp_res_ws_memsize(struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_res_ws_create(struct s_dense_qp_dim *dim, struct s_dense_qp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_s_dense_qp_res.h
+++ b/include/hpipm_s_dense_qp_res.h
@@ -62,7 +62,7 @@ struct s_dense_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -71,7 +71,7 @@ struct s_dense_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbg; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_ns; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qp_sol.h
+++ b/include/hpipm_s_dense_qp_sol.h
@@ -63,7 +63,7 @@ struct s_dense_qp_sol
 	void *misc;
 	float obj;
 	int valid_obj;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_dense_qp_sol.h
+++ b/include/hpipm_s_dense_qp_sol.h
@@ -63,13 +63,13 @@ struct s_dense_qp_sol
 	void *misc;
 	float obj;
 	int valid_obj;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_dense_qp_sol_memsize(struct s_dense_qp_dim *dim);
+hpipm_size_t s_dense_qp_sol_memsize(struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_sol_create(struct s_dense_qp_dim *dim, struct s_dense_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_ocp_qcqp.h
+++ b/include/hpipm_s_ocp_qcqp.h
@@ -67,7 +67,7 @@ struct s_ocp_qcqp
 	int **idxb; // index of box constraints
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_ocp_qcqp.h
+++ b/include/hpipm_s_ocp_qcqp.h
@@ -67,15 +67,15 @@ struct s_ocp_qcqp
 	int **idxb; // index of box constraints
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **Hq_nzero; // for each int, the last 3 bits ...abc, {a,b,c}=0 => {R,S,Q}=0
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_ocp_qcqp_strsize();
+hpipm_size_t s_ocp_qcqp_strsize();
 //
-int s_ocp_qcqp_memsize(struct s_ocp_qcqp_dim *dim);
+hpipm_size_t s_ocp_qcqp_memsize(struct s_ocp_qcqp_dim *dim);
 //
 void s_ocp_qcqp_create(struct s_ocp_qcqp_dim *dim, struct s_ocp_qcqp *qp, void *memory);
 //

--- a/include/hpipm_s_ocp_qcqp_dim.h
+++ b/include/hpipm_s_ocp_qcqp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_S_OCP_QCQP_DIM_H_
 #define HPIPM_S_OCP_QCQP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +60,15 @@ struct s_ocp_qcqp_dim
 	int *nsg; // number of (two-sided) soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int N; // horizon length
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qcqp_dim_strsize();
+hpipm_size_t s_ocp_qcqp_dim_strsize();
 //
-int s_ocp_qcqp_dim_memsize(int N);
+hpipm_size_t s_ocp_qcqp_dim_memsize(int N);
 //
 void s_ocp_qcqp_dim_create(int N, struct s_ocp_qcqp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_s_ocp_qcqp_dim.h
+++ b/include/hpipm_s_ocp_qcqp_dim.h
@@ -60,7 +60,7 @@ struct s_ocp_qcqp_dim
 	int *nsg; // number of (two-sided) soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int N; // horizon length
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qcqp_ipm.h
+++ b/include/hpipm_s_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct s_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -98,15 +98,15 @@ struct s_ocp_qcqp_ipm_ws
 	struct blasfeo_svec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qcqp_ipm_arg_strseize();
+hpipm_size_t s_ocp_qcqp_ipm_arg_strsize();
 //
-int s_ocp_qcqp_ipm_arg_memsize(struct s_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_ocp_qcqp_ipm_arg_memsize(struct s_ocp_qcqp_dim *ocp_dim);
 //
 void s_ocp_qcqp_ipm_arg_create(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_ipm_arg *arg, void *mem);
 //
@@ -151,9 +151,9 @@ void s_ocp_qcqp_ipm_arg_set_split_step(int *value, struct s_ocp_qcqp_ipm_arg *ar
 void s_ocp_qcqp_ipm_arg_set_t_lam_min(int *value, struct s_ocp_qcqp_ipm_arg *arg);
 
 //
-int s_ocp_qcqp_ipm_ws_strsize();
+hpipm_size_t s_ocp_qcqp_ipm_ws_strsize();
 //
-int s_ocp_qcqp_ipm_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_ipm_arg *arg);
+hpipm_size_t s_ocp_qcqp_ipm_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_ipm_arg *arg);
 //
 void s_ocp_qcqp_ipm_ws_create(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_ipm_arg *arg, struct s_ocp_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_ocp_qcqp_ipm.h
+++ b/include/hpipm_s_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct s_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -98,7 +98,7 @@ struct s_ocp_qcqp_ipm_ws
 	struct blasfeo_svec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qcqp_res.h
+++ b/include/hpipm_s_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct s_ocp_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -77,17 +77,17 @@ struct s_ocp_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qcqp_res_memsize(struct s_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_ocp_qcqp_res_memsize(struct s_ocp_qcqp_dim *ocp_dim);
 //
 void s_ocp_qcqp_res_create(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_res *res, void *mem);
 //
-int s_ocp_qcqp_res_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_ocp_qcqp_res_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim);
 //
 void s_ocp_qcqp_res_ws_create(struct s_ocp_qcqp_dim *ocp_dim, struct s_ocp_qcqp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_s_ocp_qcqp_res.h
+++ b/include/hpipm_s_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct s_ocp_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -77,7 +77,7 @@ struct s_ocp_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qcqp_sol.h
+++ b/include/hpipm_s_ocp_qcqp_sol.h
@@ -58,7 +58,7 @@ struct s_ocp_qcqp_sol
 	struct blasfeo_svec *pi;
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_ocp_qcqp_sol.h
+++ b/include/hpipm_s_ocp_qcqp_sol.h
@@ -58,15 +58,15 @@ struct s_ocp_qcqp_sol
 	struct blasfeo_svec *pi;
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_ocp_qcqp_sol_strsize();
+hpipm_size_t s_ocp_qcqp_sol_strsize();
 //
-int s_ocp_qcqp_sol_memsize(struct s_ocp_qcqp_dim *dim);
+hpipm_size_t s_ocp_qcqp_sol_memsize(struct s_ocp_qcqp_dim *dim);
 //
 void s_ocp_qcqp_sol_create(struct s_ocp_qcqp_dim *dim, struct s_ocp_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_ocp_qp.h
+++ b/include/hpipm_s_ocp_qp.h
@@ -67,15 +67,15 @@ struct s_ocp_qp
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **idxe; // index of equality constraints
 	int *diag_H_flag; // flag the fact that Hessian is diagonal
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_ocp_qp_strsize();
+hpipm_size_t s_ocp_qp_strsize();
 //
-int s_ocp_qp_memsize(struct s_ocp_qp_dim *dim);
+hpipm_size_t s_ocp_qp_memsize(struct s_ocp_qp_dim *dim);
 //
 void s_ocp_qp_create(struct s_ocp_qp_dim *dim, struct s_ocp_qp *qp, void *memory);
 //

--- a/include/hpipm_s_ocp_qp.h
+++ b/include/hpipm_s_ocp_qp.h
@@ -67,7 +67,7 @@ struct s_ocp_qp
 	int **idxs_rev; // index of soft constraints (reverse storage)
 	int **idxe; // index of equality constraints
 	int *diag_H_flag; // flag the fact that Hessian is diagonal
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_ocp_qp_dim.h
+++ b/include/hpipm_s_ocp_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_S_OCP_QP_DIM_H_
 #define HPIPM_S_OCP_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +60,15 @@ struct s_ocp_qp_dim
 	int *nbue; // number of input box constraints which are equality
 	int *nge; // number of general constraints which are equality
 	int N; // horizon length
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qp_dim_strsize();
+hpipm_size_t s_ocp_qp_dim_strsize();
 //
-int s_ocp_qp_dim_memsize(int N);
+hpipm_size_t s_ocp_qp_dim_memsize(int N);
 //
 void s_ocp_qp_dim_create(int N, struct s_ocp_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_s_ocp_qp_dim.h
+++ b/include/hpipm_s_ocp_qp_dim.h
@@ -60,7 +60,7 @@ struct s_ocp_qp_dim
 	int *nbue; // number of input box constraints which are equality
 	int *nge; // number of general constraints which are equality
 	int N; // horizon length
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qp_ipm.h
+++ b/include/hpipm_s_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct s_ocp_qp_ipm_arg
 	int var_init_scheme; // variables initialization scheme
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -130,7 +130,7 @@ struct s_ocp_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int valid_ric_vec; // meaningful riccati vectors
 	int valid_ric_p; // form of riccati p: 0 p*inv(L), 1 p
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qp_ipm.h
+++ b/include/hpipm_s_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct s_ocp_qp_ipm_arg
 	int var_init_scheme; // variables initialization scheme
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -130,15 +130,15 @@ struct s_ocp_qp_ipm_ws
 	int mask_constr; // use constr mask
 	int valid_ric_vec; // meaningful riccati vectors
 	int valid_ric_p; // form of riccati p: 0 p*inv(L), 1 p
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qp_ipm_arg_strsize();
+hpipm_size_t s_ocp_qp_ipm_arg_strsize();
 //
-int s_ocp_qp_ipm_arg_memsize(struct s_ocp_qp_dim *ocp_dim);
+hpipm_size_t s_ocp_qp_ipm_arg_memsize(struct s_ocp_qp_dim *ocp_dim);
 //
 void s_ocp_qp_ipm_arg_create(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_ipm_arg *arg, void *mem);
 //
@@ -189,9 +189,9 @@ void s_ocp_qp_ipm_arg_set_var_init_scheme(int *value, struct s_ocp_qp_ipm_arg *a
 void s_ocp_qp_ipm_arg_set_t_lam_min(int *value, struct s_ocp_qp_ipm_arg *arg);
 
 //
-int s_ocp_qp_ipm_ws_strsize();
+hpipm_size_t s_ocp_qp_ipm_ws_strsize();
 //
-int s_ocp_qp_ipm_ws_memsize(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_ipm_arg *arg);
+hpipm_size_t s_ocp_qp_ipm_ws_memsize(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_ipm_arg *arg);
 //
 void s_ocp_qp_ipm_ws_create(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_ipm_arg *arg, struct s_ocp_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_ocp_qp_red.h
+++ b/include/hpipm_s_ocp_qp_red.h
@@ -61,7 +61,7 @@ struct s_ocp_qp_reduce_eq_dof_arg
 	int comp_prim_sol; // primal solution (v)
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -72,7 +72,7 @@ struct s_ocp_qp_reduce_eq_dof_ws
 	struct blasfeo_svec *tmp_nbgM;
 	int *e_imask_ux;
 	int *e_imask_d;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -80,7 +80,7 @@ struct s_ocp_qp_reduce_eq_dof_ws
 //
 void s_ocp_qp_dim_reduce_eq_dof(struct s_ocp_qp_dim *dim, struct s_ocp_qp_dim *dim_red);
 //
-int s_ocp_qp_reduce_eq_dof_arg_memsize();
+hpipm_size_t s_ocp_qp_reduce_eq_dof_arg_memsize();
 //
 void s_ocp_qp_reduce_eq_dof_arg_create(struct s_ocp_qp_reduce_eq_dof_arg *arg, void *mem);
 //
@@ -94,7 +94,7 @@ void s_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_eq(struct s_ocp_qp_reduce_eq_d
 //
 void s_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_ineq(struct s_ocp_qp_reduce_eq_dof_arg *arg, int value);
 //
-int s_ocp_qp_reduce_eq_dof_ws_memsize(struct s_ocp_qp_dim *dim);
+hpipm_size_t s_ocp_qp_reduce_eq_dof_ws_memsize(struct s_ocp_qp_dim *dim);
 //
 void s_ocp_qp_reduce_eq_dof_ws_create(struct s_ocp_qp_dim *dim, struct s_ocp_qp_reduce_eq_dof_ws *work, void *mem);
 //

--- a/include/hpipm_s_ocp_qp_red.h
+++ b/include/hpipm_s_ocp_qp_red.h
@@ -61,7 +61,7 @@ struct s_ocp_qp_reduce_eq_dof_arg
 	int comp_prim_sol; // primal solution (v)
 	int comp_dual_sol_eq; // dual solution equality constr (pi)
 	int comp_dual_sol_ineq; // dual solution inequality constr (lam t)
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 
@@ -72,7 +72,7 @@ struct s_ocp_qp_reduce_eq_dof_ws
 	struct blasfeo_svec *tmp_nbgM;
 	int *e_imask_ux;
 	int *e_imask_d;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_ocp_qp_res.h
+++ b/include/hpipm_s_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct s_ocp_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -72,17 +72,17 @@ struct s_ocp_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_nsM; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_ocp_qp_res_memsize(struct s_ocp_qp_dim *ocp_dim);
+hpipm_size_t s_ocp_qp_res_memsize(struct s_ocp_qp_dim *ocp_dim);
 //
 void s_ocp_qp_res_create(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_res *res, void *mem);
 //
-int s_ocp_qp_res_ws_memsize(struct s_ocp_qp_dim *ocp_dim);
+hpipm_size_t s_ocp_qp_res_ws_memsize(struct s_ocp_qp_dim *ocp_dim);
 //
 void s_ocp_qp_res_ws_create(struct s_ocp_qp_dim *ocp_dim, struct s_ocp_qp_res_ws *workspace, void *mem);
 //

--- a/include/hpipm_s_ocp_qp_res.h
+++ b/include/hpipm_s_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct s_ocp_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -72,7 +72,7 @@ struct s_ocp_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_nsM; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_ocp_qp_sol.h
+++ b/include/hpipm_s_ocp_qp_sol.h
@@ -59,7 +59,7 @@ struct s_ocp_qp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_ocp_qp_sol.h
+++ b/include/hpipm_s_ocp_qp_sol.h
@@ -59,15 +59,15 @@ struct s_ocp_qp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_ocp_qp_sol_strsize();
+hpipm_size_t s_ocp_qp_sol_strsize();
 //
-int s_ocp_qp_sol_memsize(struct s_ocp_qp_dim *dim);
+hpipm_size_t s_ocp_qp_sol_memsize(struct s_ocp_qp_dim *dim);
 //
 void s_ocp_qp_sol_create(struct s_ocp_qp_dim *dim, struct s_ocp_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_part_cond.h
+++ b/include/hpipm_s_part_cond.h
@@ -57,7 +57,7 @@ struct s_part_cond_qp_arg
 	{
 	struct s_cond_qp_arg *cond_arg;
 	int N2;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -65,13 +65,13 @@ struct s_part_cond_qp_arg
 struct s_part_cond_qp_ws
 	{
 	struct s_cond_qp_ws *cond_workspace;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_part_cond_qp_arg_memsize(int N2);
+hpipm_size_t s_part_cond_qp_arg_memsize(int N2);
 //
 void s_part_cond_qp_arg_create(int N2, struct s_part_cond_qp_arg *cond_arg, void *mem);
 //
@@ -90,7 +90,7 @@ void s_part_cond_qp_compute_block_size(int N, int N2, int *block_size);
 //
 void s_part_cond_qp_compute_dim(struct s_ocp_qp_dim *ocp_dim, int *block_size, struct s_ocp_qp_dim *part_dense_dim);
 //
-int s_part_cond_qp_ws_memsize(struct s_ocp_qp_dim *ocp_dim, int *block_size, struct s_ocp_qp_dim *part_dense_dim, struct s_part_cond_qp_arg *cond_arg);
+hpipm_size_t s_part_cond_qp_ws_memsize(struct s_ocp_qp_dim *ocp_dim, int *block_size, struct s_ocp_qp_dim *part_dense_dim, struct s_part_cond_qp_arg *cond_arg);
 //
 void s_part_cond_qp_ws_create(struct s_ocp_qp_dim *ocp_dim, int *block_size, struct s_ocp_qp_dim *part_dense_dim, struct s_part_cond_qp_arg *cond_arg, struct s_part_cond_qp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_s_part_cond.h
+++ b/include/hpipm_s_part_cond.h
@@ -57,7 +57,7 @@ struct s_part_cond_qp_arg
 	{
 	struct s_cond_qp_arg *cond_arg;
 	int N2;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -65,7 +65,7 @@ struct s_part_cond_qp_arg
 struct s_part_cond_qp_ws
 	{
 	struct s_cond_qp_ws *cond_workspace;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_part_cond_qcqp.h
+++ b/include/hpipm_s_part_cond_qcqp.h
@@ -56,7 +56,7 @@ struct s_part_cond_qcqp_arg
 	{
 	struct s_cond_qcqp_arg *cond_arg;
 	int N2;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -64,13 +64,13 @@ struct s_part_cond_qcqp_arg
 struct s_part_cond_qcqp_ws
 	{
 	struct s_cond_qcqp_ws *cond_ws;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_part_cond_qcqp_arg_memsize(int N2);
+hpipm_size_t s_part_cond_qcqp_arg_memsize(int N2);
 //
 void s_part_cond_qcqp_arg_create(int N2, struct s_part_cond_qcqp_arg *cond_arg, void *mem);
 //
@@ -83,7 +83,7 @@ void s_part_cond_qcqp_compute_block_size(int N, int N2, int *block_size);
 //
 void s_part_cond_qcqp_compute_dim(struct s_ocp_qcqp_dim *ocp_dim, int *block_size, struct s_ocp_qcqp_dim *part_dense_dim);
 //
-int s_part_cond_qcqp_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, int *block_size, struct s_ocp_qcqp_dim *part_dense_dim, struct s_part_cond_qcqp_arg *cond_arg);
+hpipm_size_t s_part_cond_qcqp_ws_memsize(struct s_ocp_qcqp_dim *ocp_dim, int *block_size, struct s_ocp_qcqp_dim *part_dense_dim, struct s_part_cond_qcqp_arg *cond_arg);
 //
 void s_part_cond_qcqp_ws_create(struct s_ocp_qcqp_dim *ocp_dim, int *block_size, struct s_ocp_qcqp_dim *part_dense_dim, struct s_part_cond_qcqp_arg *cond_arg, struct s_part_cond_qcqp_ws *cond_ws, void *mem);
 //

--- a/include/hpipm_s_part_cond_qcqp.h
+++ b/include/hpipm_s_part_cond_qcqp.h
@@ -56,7 +56,7 @@ struct s_part_cond_qcqp_arg
 	{
 	struct s_cond_qcqp_arg *cond_arg;
 	int N2;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -64,7 +64,7 @@ struct s_part_cond_qcqp_arg
 struct s_part_cond_qcqp_ws
 	{
 	struct s_cond_qcqp_ws *cond_ws;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_sim_erk.h
+++ b/include/hpipm_s_sim_erk.h
@@ -47,7 +47,7 @@ struct s_sim_erk_arg
 	int steps; // number of steps
 //	int for_sens; // compute adjoint sensitivities
 //	int adj_sens; // compute adjoint sensitivities
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -73,20 +73,20 @@ struct s_sim_erk_ws
 	int na; // number of adjoint sensitivities
 	int nf_max; // max number of forward sensitivities
 	int na_max; // max number of adjoint sensitivities
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_sim_erk_arg_memsize();
+hpipm_size_t s_sim_erk_arg_memsize();
 //
 void s_sim_erk_arg_create(struct s_sim_erk_arg *erk_arg, void *mem);
 //
 void s_sim_erk_arg_set_all(struct s_sim_rk_data *rk_data, float h, int steps, struct s_sim_erk_arg *erk_arg);
 
 //
-int s_sim_erk_ws_memsize(struct s_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max);
+hpipm_size_t s_sim_erk_ws_memsize(struct s_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max);
 //
 void s_sim_erk_ws_create(struct s_sim_erk_arg *erk_arg, int nx, int np, int nf_max, int na_max, struct s_sim_erk_ws *work, void *memory);
 //

--- a/include/hpipm_s_sim_erk.h
+++ b/include/hpipm_s_sim_erk.h
@@ -47,7 +47,7 @@ struct s_sim_erk_arg
 	int steps; // number of steps
 //	int for_sens; // compute adjoint sensitivities
 //	int adj_sens; // compute adjoint sensitivities
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -73,7 +73,7 @@ struct s_sim_erk_ws
 	int na; // number of adjoint sensitivities
 	int nf_max; // max number of forward sensitivities
 	int na_max; // max number of adjoint sensitivities
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_sim_rk.h
+++ b/include/hpipm_s_sim_rk.h
@@ -36,6 +36,8 @@
 #ifndef HPIPM_S_SIM_RK_H_
 #define HPIPM_S_SIM_RK_H_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,13 +49,13 @@ struct s_sim_rk_data
 	float *C_rk; // c in butcher tableau
 	int expl; // erk vs irk
 	int ns; // number of stages
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_sim_rk_data_memsize(int ns);
+hpipm_size_t s_sim_rk_data_memsize(int ns);
 //
 void s_sim_rk_data_create(int ns, struct s_sim_rk_data *rk_data, void *memory);
 //

--- a/include/hpipm_s_sim_rk.h
+++ b/include/hpipm_s_sim_rk.h
@@ -49,7 +49,7 @@ struct s_sim_rk_data
 	float *C_rk; // c in butcher tableau
 	int expl; // erk vs irk
 	int ns; // number of stages
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qcqp.h
+++ b/include/hpipm_s_tree_ocp_qcqp.h
@@ -66,13 +66,13 @@ struct s_tree_ocp_qcqp
 	struct blasfeo_svec *Z; // Nn
 	int **idxb; // index of box constraints // Nn
 	int **idxs_rev; // index of soft constraints
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_tree_ocp_qcqp_memsize(struct s_tree_ocp_qcqp_dim *dim);
+hpipm_size_t s_tree_ocp_qcqp_memsize(struct s_tree_ocp_qcqp_dim *dim);
 //
 void s_tree_ocp_qcqp_create(struct s_tree_ocp_qcqp_dim *dim, struct s_tree_ocp_qcqp *qp, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qcqp.h
+++ b/include/hpipm_s_tree_ocp_qcqp.h
@@ -66,7 +66,7 @@ struct s_tree_ocp_qcqp
 	struct blasfeo_svec *Z; // Nn
 	int **idxb; // index of box constraints // Nn
 	int **idxs_rev; // index of soft constraints
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qcqp_dim.h
+++ b/include/hpipm_s_tree_ocp_qcqp_dim.h
@@ -61,7 +61,7 @@ struct s_tree_ocp_qcqp_dim
 	int *nsg; // number of soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int Nn; // number of nodes
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qcqp_dim.h
+++ b/include/hpipm_s_tree_ocp_qcqp_dim.h
@@ -61,15 +61,15 @@ struct s_tree_ocp_qcqp_dim
 	int *nsg; // number of soft general constraints
 	int *nsq; // number of (upper) soft quadratic constraints
 	int Nn; // number of nodes
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qcqp_dim_strsize();
+hpipm_size_t s_tree_ocp_qcqp_dim_strsize();
 //
-int s_tree_ocp_qcqp_dim_memsize(int Nn);
+hpipm_size_t s_tree_ocp_qcqp_dim_memsize(int Nn);
 //
 void s_tree_ocp_qcqp_dim_create(int Nn, struct s_tree_ocp_qcqp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qcqp_ipm.h
+++ b/include/hpipm_s_tree_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct s_tree_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -98,15 +98,15 @@ struct s_tree_ocp_qcqp_ipm_ws
 	struct blasfeo_svec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qcqp_ipm_arg_strseize();
+hpipm_size_t s_tree_ocp_qcqp_ipm_arg_strsize();
 //
-int s_tree_ocp_qcqp_ipm_arg_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_tree_ocp_qcqp_ipm_arg_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
 //
 void s_tree_ocp_qcqp_ipm_arg_create(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_ipm_arg *arg, void *mem);
 //
@@ -151,9 +151,9 @@ void s_tree_ocp_qcqp_ipm_arg_set_split_step(int *value, struct s_tree_ocp_qcqp_i
 void s_tree_ocp_qcqp_ipm_arg_set_t_lam_min(int *value, struct s_tree_ocp_qcqp_ipm_arg *arg);
 
 //
-int s_tree_ocp_qcqp_ipm_ws_strsize();
+hpipm_size_t s_tree_ocp_qcqp_ipm_ws_strsize();
 //
-int s_tree_ocp_qcqp_ipm_ws_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_ipm_arg *arg);
+hpipm_size_t s_tree_ocp_qcqp_ipm_ws_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_ipm_arg *arg);
 //
 void s_tree_ocp_qcqp_ipm_ws_create(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_ipm_arg *arg, struct s_tree_ocp_qcqp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_tree_ocp_qcqp_ipm.h
+++ b/include/hpipm_s_tree_ocp_qcqp_ipm.h
@@ -83,7 +83,7 @@ struct s_tree_ocp_qcqp_ipm_arg
 	int split_step; // use different step for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -98,7 +98,7 @@ struct s_tree_ocp_qcqp_ipm_ws
 	struct blasfeo_svec *tmp_nuxM;
 	int iter; // iteration number
 	int status;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qcqp_res.h
+++ b/include/hpipm_s_tree_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct s_tree_ocp_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -77,17 +77,17 @@ struct s_tree_ocp_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qcqp_res_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_tree_ocp_qcqp_res_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
 //
 void s_tree_ocp_qcqp_res_create(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_res *res, void *mem);
 //
-int s_tree_ocp_qcqp_res_ws_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
+hpipm_size_t s_tree_ocp_qcqp_res_ws_memsize(struct s_tree_ocp_qcqp_dim *ocp_dim);
 //
 void s_tree_ocp_qcqp_res_ws_create(struct s_tree_ocp_qcqp_dim *ocp_dim, struct s_tree_ocp_qcqp_res_ws *ws, void *mem);
 //

--- a/include/hpipm_s_tree_ocp_qcqp_res.h
+++ b/include/hpipm_s_tree_ocp_qcqp_res.h
@@ -63,7 +63,7 @@ struct s_tree_ocp_qcqp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -77,7 +77,7 @@ struct s_tree_ocp_qcqp_res_ws
 	struct blasfeo_svec *q_adj; // value for adjoint of quadr constr
 	int use_q_fun; // reuse cached value for evaluation of quadr constr
 	int use_q_adj; // reuse cached value for adjoint of quadr constr
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qcqp_sol.h
+++ b/include/hpipm_s_tree_ocp_qcqp_sol.h
@@ -57,13 +57,13 @@ struct s_tree_ocp_qcqp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_tree_ocp_qcqp_sol_memsize(struct s_tree_ocp_qcqp_dim *dim);
+hpipm_size_t s_tree_ocp_qcqp_sol_memsize(struct s_tree_ocp_qcqp_dim *dim);
 //
 void s_tree_ocp_qcqp_sol_create(struct s_tree_ocp_qcqp_dim *dim, struct s_tree_ocp_qcqp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qcqp_sol.h
+++ b/include/hpipm_s_tree_ocp_qcqp_sol.h
@@ -57,7 +57,7 @@ struct s_tree_ocp_qcqp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qp.h
+++ b/include/hpipm_s_tree_ocp_qp.h
@@ -66,7 +66,7 @@ struct s_tree_ocp_qp
 	int **idxb; // index of box constraints // Nn
 //	int **idxs; // index of soft constraints
 	int **idxs_rev; // index of soft constraints
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qp.h
+++ b/include/hpipm_s_tree_ocp_qp.h
@@ -66,13 +66,13 @@ struct s_tree_ocp_qp
 	int **idxb; // index of box constraints // Nn
 //	int **idxs; // index of soft constraints
 	int **idxs_rev; // index of soft constraints
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_tree_ocp_qp_memsize(struct s_tree_ocp_qp_dim *dim);
+hpipm_size_t s_tree_ocp_qp_memsize(struct s_tree_ocp_qp_dim *dim);
 //
 void s_tree_ocp_qp_create(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp *qp, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qp_dim.h
+++ b/include/hpipm_s_tree_ocp_qp_dim.h
@@ -36,7 +36,7 @@
 #ifndef HPIPM_S_TREE_OCP_QP_DIM_H_
 #define HPIPM_S_TREE_OCP_QP_DIM_H_
 
-
+#include "hpipm_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,15 +58,15 @@ struct s_tree_ocp_qp_dim
 	int *nsbu; // number of soft input box constraints
 	int *nsg; // number of soft general constraints
 	int Nn; // number of nodes
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qp_dim_strsize();
+hpipm_size_t s_tree_ocp_qp_dim_strsize();
 //
-int s_tree_ocp_qp_dim_memsize(int Nn);
+hpipm_size_t s_tree_ocp_qp_dim_memsize(int Nn);
 //
 void s_tree_ocp_qp_dim_create(int Nn, struct s_tree_ocp_qp_dim *qp_dim, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qp_dim.h
+++ b/include/hpipm_s_tree_ocp_qp_dim.h
@@ -58,7 +58,7 @@ struct s_tree_ocp_qp_dim
 	int *nsbu; // number of soft input box constraints
 	int *nsg; // number of soft general constraints
 	int Nn; // number of nodes
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qp_ipm.h
+++ b/include/hpipm_s_tree_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct s_tree_ocp_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -122,7 +122,7 @@ struct s_tree_ocp_qp_ipm_ws
 	int status; // solver status
 	int lq_fact; // cache from arg
 	int mask_constr; // use constr mask
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qp_ipm.h
+++ b/include/hpipm_s_tree_ocp_qp_ipm.h
@@ -84,7 +84,7 @@ struct s_tree_ocp_qp_ipm_arg
 	int split_step; // use different steps for primal and dual variables
 	int t_lam_min; // clip t and lam: 0 no, 1 in Gamma computation, 2 in solution
 	int mode;
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -122,13 +122,13 @@ struct s_tree_ocp_qp_ipm_ws
 	int status; // solver status
 	int lq_fact; // cache from arg
 	int mask_constr; // use constr mask
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qp_ipm_arg_memsize(struct s_tree_ocp_qp_dim *dim);
+hpipm_size_t s_tree_ocp_qp_ipm_arg_memsize(struct s_tree_ocp_qp_dim *dim);
 //
 void s_tree_ocp_qp_ipm_arg_create(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp_ipm_arg *arg, void *mem);
 //
@@ -171,7 +171,7 @@ void s_tree_ocp_qp_ipm_arg_set_split_step(int *value, struct s_tree_ocp_qp_ipm_a
 void s_tree_ocp_qp_ipm_arg_set_t_lam_min(int *value, struct s_tree_ocp_qp_ipm_arg *arg);
 
 //
-int s_tree_ocp_qp_ipm_ws_memsize(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp_ipm_arg *arg);
+hpipm_size_t s_tree_ocp_qp_ipm_ws_memsize(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp_ipm_arg *arg);
 //
 void s_tree_ocp_qp_ipm_ws_create(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp_ipm_arg *arg, struct s_tree_ocp_qp_ipm_ws *ws, void *mem);
 //

--- a/include/hpipm_s_tree_ocp_qp_res.h
+++ b/include/hpipm_s_tree_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct s_tree_ocp_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
@@ -72,17 +72,17 @@ struct s_tree_ocp_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_nsM; // work space of size nsM
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int s_tree_ocp_qp_res_memsize(struct s_tree_ocp_qp_dim *ocp_dim);
+hpipm_size_t s_tree_ocp_qp_res_memsize(struct s_tree_ocp_qp_dim *ocp_dim);
 //
 void s_tree_ocp_qp_res_create(struct s_tree_ocp_qp_dim *ocp_dim, struct s_tree_ocp_qp_res *res, void *mem);
 //
-int s_tree_ocp_qp_res_ws_memsize(struct s_tree_ocp_qp_dim *ocp_dim);
+hpipm_size_t s_tree_ocp_qp_res_ws_memsize(struct s_tree_ocp_qp_dim *ocp_dim);
 //
 void s_tree_ocp_qp_res_ws_create(struct s_tree_ocp_qp_dim *ocp_dim, struct s_tree_ocp_qp_res_ws *ws, void *mem);
 //

--- a/include/hpipm_s_tree_ocp_qp_res.h
+++ b/include/hpipm_s_tree_ocp_qp_res.h
@@ -63,7 +63,7 @@ struct s_tree_ocp_qp_res
 	struct blasfeo_svec *res_m; // m-residuals
 	float res_max[4]; // max of residuals
 	float res_mu; // mu-residual
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 
@@ -72,7 +72,7 @@ struct s_tree_ocp_qp_res_ws
 	{
 	struct blasfeo_svec *tmp_nbgM; // work space of size nbM+ngM
 	struct blasfeo_svec *tmp_nsM; // work space of size nsM
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_s_tree_ocp_qp_sol.h
+++ b/include/hpipm_s_tree_ocp_qp_sol.h
@@ -57,13 +57,13 @@ struct s_tree_ocp_qp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-	int memsize; // memory size in bytes
+    hpipm_size_t memsize; // memory size in bytes
 	};
 
 
 
 //
-int s_tree_ocp_qp_sol_memsize(struct s_tree_ocp_qp_dim *dim);
+hpipm_size_t s_tree_ocp_qp_sol_memsize(struct s_tree_ocp_qp_dim *dim);
 //
 void s_tree_ocp_qp_sol_create(struct s_tree_ocp_qp_dim *dim, struct s_tree_ocp_qp_sol *qp_sol, void *memory);
 //

--- a/include/hpipm_s_tree_ocp_qp_sol.h
+++ b/include/hpipm_s_tree_ocp_qp_sol.h
@@ -57,7 +57,7 @@ struct s_tree_ocp_qp_sol
 	struct blasfeo_svec *lam;
 	struct blasfeo_svec *t;
 	void *misc;
-    hpipm_size_t memsize; // memory size in bytes
+	hpipm_size_t memsize; // memory size in bytes
 	};
 
 

--- a/include/hpipm_scenario_tree.h
+++ b/include/hpipm_scenario_tree.h
@@ -50,7 +50,7 @@ struct sctree
 	int md; // number of realizations
 	int Nr; // robust horizion
 	int Nh; // control horizion
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_scenario_tree.h
+++ b/include/hpipm_scenario_tree.h
@@ -50,13 +50,13 @@ struct sctree
 	int md; // number of realizations
 	int Nr; // robust horizion
 	int Nh; // control horizion
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 
 
 //
-int sctree_memsize(int md, int Nr, int Nh);
+hpipm_size_t sctree_memsize(int md, int Nr, int Nh);
 //
 void sctree_create(int md, int Nr, int Nh, struct sctree *st, void *memory);
 //

--- a/include/hpipm_tree.h
+++ b/include/hpipm_tree.h
@@ -64,7 +64,7 @@ struct tree
 	struct node *root; // pointer to root
 	int *kids; // pointer to array of kids
 	int Nn; // numer of nodes
-    hpipm_size_t memsize;
+	hpipm_size_t memsize;
 	};
 
 

--- a/include/hpipm_tree.h
+++ b/include/hpipm_tree.h
@@ -37,6 +37,8 @@
 #ifndef HPIPM_TREE_H_
 #define HPIPM_TREE_H_
 
+#include "hpipm_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -62,7 +64,7 @@ struct tree
 	struct node *root; // pointer to root
 	int *kids; // pointer to array of kids
 	int Nn; // numer of nodes
-	int memsize;
+    hpipm_size_t memsize;
 	};
 
 

--- a/interfaces/archive/octave/HPIPM_d_solve_ipm2_hard_ocp_qp.c
+++ b/interfaces/archive/octave/HPIPM_d_solve_ipm2_hard_ocp_qp.c
@@ -398,7 +398,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	// Partial condensing horizon
 //	int N2 = N;
 
-//	int work_space_size = hpmpc_d_ip_ocp_hard_tv_work_space_size_bytes(N, nx_v, nu_v, nb_v, hidxb, ng_v, N2);
+//	hpipm_size_t work_space_size = hpmpc_d_ip_ocp_hard_tv_work_space_size_bytes(N, nx_v, nu_v, nb_v, hidxb, ng_v, N2);
 //	void *work = malloc( work_space_size );
 
 
@@ -410,7 +410,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 
 	// qp dim
-	int dim_size = d_memsize_ocp_qp_dim(N);
+	hpipm_size_t dim_size = d_memsize_ocp_qp_dim(N);
 	void *dim_mem = malloc(dim_size);
 
 	struct d_ocp_qp_dim dim;
@@ -422,7 +422,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 
 	// qp
-	int qp_size = d_memsize_ocp_qp(&dim);
+	hpipm_size_t qp_size = d_memsize_ocp_qp(&dim);
 	void *qp_mem = malloc(qp_size);
 	struct d_ocp_qp qp;
 	d_create_ocp_qp(&dim, &qp, qp_mem);
@@ -430,14 +430,14 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 
 	// qp sol
-	int qp_sol_size = d_memsize_ocp_qp_sol(&dim);
+	hpipm_size_t qp_sol_size = d_memsize_ocp_qp_sol(&dim);
 	void *qp_sol_mem = malloc(qp_sol_size);
 	struct d_ocp_qp_sol qp_sol;
 	d_create_ocp_qp_sol(&dim, &qp_sol, qp_sol_mem);
 
 
 	// ipm arg
-	int ipm_arg_size = d_memsize_ocp_qp_ipm_arg(&dim);
+	hpipm_size_t ipm_arg_size = d_memsize_ocp_qp_ipm_arg(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -460,7 +460,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 
 	// ipm
-	int ipm_size = d_memsize_ocp_qp_ipm(&dim, &arg);
+	hpipm_size_t ipm_size = d_memsize_ocp_qp_ipm(&dim, &arg);
 	void *ipm_mem = malloc(ipm_size);
 
 	struct d_ocp_qp_ipm_workspace workspace;

--- a/interfaces/matlab_octave/dense_qp_create.c
+++ b/interfaces/matlab_octave/dense_qp_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int qp_size = sizeof(struct d_dense_qp) + d_dense_qp_memsize(dim);
+	hpipm_size_t qp_size = sizeof(struct d_dense_qp) + d_dense_qp_memsize(dim);
 	void *qp_mem = malloc(qp_size);
 
 	c_ptr = qp_mem;

--- a/interfaces/matlab_octave/dense_qp_dim_create.c
+++ b/interfaces/matlab_octave/dense_qp_dim_create.c
@@ -56,7 +56,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int dim_size = sizeof(struct d_dense_qp_dim) + d_dense_qp_dim_memsize();
+	hpipm_size_t dim_size = sizeof(struct d_dense_qp_dim) + d_dense_qp_dim_memsize();
 	void *dim_mem = malloc(dim_size);
 
 	c_ptr = dim_mem;

--- a/interfaces/matlab_octave/dense_qp_sol_create.c
+++ b/interfaces/matlab_octave/dense_qp_sol_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int sol_size = sizeof(struct d_dense_qp_sol) + d_dense_qp_sol_memsize(dim);
+	hpipm_size_t sol_size = sizeof(struct d_dense_qp_sol) + d_dense_qp_sol_memsize(dim);
 	void *sol_mem = malloc(sol_size);
 
 	c_ptr = sol_mem;

--- a/interfaces/matlab_octave/dense_qp_solver_arg_create.c
+++ b/interfaces/matlab_octave/dense_qp_solver_arg_create.c
@@ -88,7 +88,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int arg_size = sizeof(struct d_dense_qp_ipm_arg) + d_dense_qp_ipm_arg_memsize(dim);
+	hpipm_size_t arg_size = sizeof(struct d_dense_qp_ipm_arg) + d_dense_qp_ipm_arg_memsize(dim);
 	void *arg_mem = malloc(arg_size);
 
 	c_ptr = arg_mem;

--- a/interfaces/matlab_octave/dense_qp_solver_create.c
+++ b/interfaces/matlab_octave/dense_qp_solver_create.c
@@ -65,7 +65,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int ws_size = sizeof(struct d_dense_qp_ipm_ws) + d_dense_qp_ipm_ws_memsize(dim, arg);
+	hpipm_size_t ws_size = sizeof(struct d_dense_qp_ipm_ws) + d_dense_qp_ipm_ws_memsize(dim, arg);
 	void *ws_mem = malloc(ws_size);
 
 	c_ptr = ws_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_create.c
+++ b/interfaces/matlab_octave/ocp_qcqp_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int qp_size = sizeof(struct d_ocp_qcqp) + d_ocp_qcqp_memsize(dim);
+	hpipm_size_t qp_size = sizeof(struct d_ocp_qcqp) + d_ocp_qcqp_memsize(dim);
 	void *qp_mem = malloc(qp_size);
 
 	c_ptr = qp_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_dim_create.c
+++ b/interfaces/matlab_octave/ocp_qcqp_dim_create.c
@@ -58,7 +58,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int dim_size = sizeof(struct d_ocp_qcqp_dim) + d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t dim_size = sizeof(struct d_ocp_qcqp_dim) + d_ocp_qcqp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	c_ptr = dim_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_dim_load.c
+++ b/interfaces/matlab_octave/ocp_qcqp_dim_load.c
@@ -62,7 +62,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* dim */
 
-	int dim_size = sizeof(struct d_ocp_qcqp_dim) + d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t dim_size = sizeof(struct d_ocp_qcqp_dim) + d_ocp_qcqp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	c_ptr = dim_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_get.c
+++ b/interfaces/matlab_octave/ocp_qcqp_get.c
@@ -87,7 +87,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 		{
 		if(nrhs==4)
 			{
-			int size_sum = 0;
+			hpipm_size_t size_sum = 0;
 			for(ii=stage0; ii<=stage1; ii++)
 				{
 				size_sum += nx[ii]*nx[ii+1];

--- a/interfaces/matlab_octave/ocp_qcqp_load.c
+++ b/interfaces/matlab_octave/ocp_qcqp_load.c
@@ -69,7 +69,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* qp */
 
-	int qp_size = sizeof(struct d_ocp_qcqp) + d_ocp_qcqp_memsize(dim);
+	hpipm_size_t qp_size = sizeof(struct d_ocp_qcqp) + d_ocp_qcqp_memsize(dim);
 	void *qp_mem = malloc(qp_size);
 
 	c_ptr = qp_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_sol_create.c
+++ b/interfaces/matlab_octave/ocp_qcqp_sol_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int sol_size = sizeof(struct d_ocp_qcqp_sol) + d_ocp_qcqp_sol_memsize(dim);
+	hpipm_size_t sol_size = sizeof(struct d_ocp_qcqp_sol) + d_ocp_qcqp_sol_memsize(dim);
 	void *sol_mem = malloc(sol_size);
 
 	c_ptr = sol_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_solver_arg_create.c
+++ b/interfaces/matlab_octave/ocp_qcqp_solver_arg_create.c
@@ -88,7 +88,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int arg_size = sizeof(struct d_ocp_qcqp_ipm_arg) + d_ocp_qcqp_ipm_arg_memsize(dim);
+	hpipm_size_t arg_size = sizeof(struct d_ocp_qcqp_ipm_arg) + d_ocp_qcqp_ipm_arg_memsize(dim);
 	void *arg_mem = malloc(arg_size);
 
 	c_ptr = arg_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_solver_arg_load.c
+++ b/interfaces/matlab_octave/ocp_qcqp_solver_arg_load.c
@@ -69,7 +69,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* arg */
 
-	int arg_size = sizeof(struct d_ocp_qcqp_ipm_arg) + d_ocp_qcqp_ipm_arg_memsize(dim);
+	hpipm_size_t arg_size = sizeof(struct d_ocp_qcqp_ipm_arg) + d_ocp_qcqp_ipm_arg_memsize(dim);
 	void *arg_mem = malloc(arg_size);
 
 	c_ptr = arg_mem;

--- a/interfaces/matlab_octave/ocp_qcqp_solver_create.c
+++ b/interfaces/matlab_octave/ocp_qcqp_solver_create.c
@@ -65,7 +65,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int ws_size = sizeof(struct d_ocp_qcqp_ipm_ws) + d_ocp_qcqp_ipm_ws_memsize(dim, arg);
+	hpipm_size_t ws_size = sizeof(struct d_ocp_qcqp_ipm_ws) + d_ocp_qcqp_ipm_ws_memsize(dim, arg);
 	void *ws_mem = malloc(ws_size);
 
 	c_ptr = ws_mem;

--- a/interfaces/matlab_octave/ocp_qp_create.c
+++ b/interfaces/matlab_octave/ocp_qp_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int qp_size = sizeof(struct d_ocp_qp) + d_ocp_qp_memsize(dim);
+	hpipm_size_t qp_size = sizeof(struct d_ocp_qp) + d_ocp_qp_memsize(dim);
 	void *qp_mem = malloc(qp_size);
 
 	c_ptr = qp_mem;

--- a/interfaces/matlab_octave/ocp_qp_dim_create.c
+++ b/interfaces/matlab_octave/ocp_qp_dim_create.c
@@ -58,7 +58,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int dim_size = sizeof(struct d_ocp_qp_dim) + d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = sizeof(struct d_ocp_qp_dim) + d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	c_ptr = dim_mem;

--- a/interfaces/matlab_octave/ocp_qp_dim_load.c
+++ b/interfaces/matlab_octave/ocp_qp_dim_load.c
@@ -62,7 +62,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* dim */
 
-	int dim_size = sizeof(struct d_ocp_qp_dim) + d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = sizeof(struct d_ocp_qp_dim) + d_ocp_qp_dim_memsize(N);
 	void *dim_mem = malloc(dim_size);
 
 	c_ptr = dim_mem;

--- a/interfaces/matlab_octave/ocp_qp_load.c
+++ b/interfaces/matlab_octave/ocp_qp_load.c
@@ -69,7 +69,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* qp */
 
-	int qp_size = sizeof(struct d_ocp_qp) + d_ocp_qp_memsize(dim);
+	hpipm_size_t qp_size = sizeof(struct d_ocp_qp) + d_ocp_qp_memsize(dim);
 	void *qp_mem = malloc(qp_size);
 
 	c_ptr = qp_mem;

--- a/interfaces/matlab_octave/ocp_qp_sol_create.c
+++ b/interfaces/matlab_octave/ocp_qp_sol_create.c
@@ -61,7 +61,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int sol_size = sizeof(struct d_ocp_qp_sol) + d_ocp_qp_sol_memsize(dim);
+	hpipm_size_t sol_size = sizeof(struct d_ocp_qp_sol) + d_ocp_qp_sol_memsize(dim);
 	void *sol_mem = malloc(sol_size);
 
 	c_ptr = sol_mem;

--- a/interfaces/matlab_octave/ocp_qp_solver_arg_create.c
+++ b/interfaces/matlab_octave/ocp_qp_solver_arg_create.c
@@ -88,7 +88,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int arg_size = sizeof(struct d_ocp_qp_ipm_arg) + d_ocp_qp_ipm_arg_memsize(dim);
+	hpipm_size_t arg_size = sizeof(struct d_ocp_qp_ipm_arg) + d_ocp_qp_ipm_arg_memsize(dim);
 	void *arg_mem = malloc(arg_size);
 
 	c_ptr = arg_mem;

--- a/interfaces/matlab_octave/ocp_qp_solver_arg_load.c
+++ b/interfaces/matlab_octave/ocp_qp_solver_arg_load.c
@@ -69,7 +69,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* arg */
 
-	int arg_size = sizeof(struct d_ocp_qp_ipm_arg) + d_ocp_qp_ipm_arg_memsize(dim);
+	hpipm_size_t arg_size = sizeof(struct d_ocp_qp_ipm_arg) + d_ocp_qp_ipm_arg_memsize(dim);
 	void *arg_mem = malloc(arg_size);
 
 	c_ptr = arg_mem;

--- a/interfaces/matlab_octave/ocp_qp_solver_create.c
+++ b/interfaces/matlab_octave/ocp_qp_solver_create.c
@@ -65,7 +65,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
 	/* body */
 
-	int ws_size = sizeof(struct d_ocp_qp_ipm_ws) + d_ocp_qp_ipm_ws_memsize(dim, arg);
+	hpipm_size_t ws_size = sizeof(struct d_ocp_qp_ipm_ws) + d_ocp_qp_ipm_ws_memsize(dim, arg);
 	void *ws_mem = malloc(ws_size);
 
 	c_ptr = ws_mem;

--- a/interfaces/simulink/hpipm_sfun.c
+++ b/interfaces/simulink/hpipm_sfun.c
@@ -164,7 +164,7 @@ static void mdlStart(SimStruct *S)
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	dim_mem = malloc(dim_size);
 	if(dim_mem == NULL) printf("Error allocating memory for dim_mem. Exiting.\n\n");
 
@@ -178,7 +178,7 @@ static void mdlStart(SimStruct *S)
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(dim);
 	qp_mem = malloc(qp_size);
 	if(qp_mem == NULL) printf("Error allocating memory for qp_mem. Exiting.\n\n");
 
@@ -192,7 +192,7 @@ static void mdlStart(SimStruct *S)
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(dim);
 	qp_sol_mem = malloc(qp_sol_size);
 	if(qp_sol_mem == NULL) printf("Error allocating memory for qp_sol_mem. Exiting.\n\n");
 
@@ -204,7 +204,7 @@ static void mdlStart(SimStruct *S)
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(dim);
 	ipm_arg_mem = malloc(ipm_arg_size);
 	if(ipm_arg_mem == NULL) printf("Error allocating memory for ipm_arg_mem. Exiting.\n\n");
 
@@ -228,7 +228,7 @@ static void mdlStart(SimStruct *S)
 * ipm workspace
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(dim, arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(dim, arg);
 	ipm_mem = malloc(ipm_size);
 
 	workspace = malloc(sizeof(struct d_ocp_qp_ipm_ws));

--- a/ipm_core/x_core_qp_ipm.c
+++ b/ipm_core/x_core_qp_ipm.c
@@ -35,10 +35,10 @@
 
 
 
-int MEMSIZE_CORE_QP_IPM(int nv, int ne, int nc)
+hpipm_size_t MEMSIZE_CORE_QP_IPM(int nv, int ne, int nc)
 	{
 
-	int size;
+	hpipm_size_t size;
 
 	int nv0 = nv;
 	int ne0 = ne;

--- a/ocp_qp/m_ocp_qp_ipm_hard.c
+++ b/ocp_qp/m_ocp_qp_ipm_hard.c
@@ -52,7 +52,7 @@
 
 
 
-int m_memsize_ipm_hard_ocp_qp(struct d_ocp_qp *qp, struct s_ocp_qp *s_qp, struct m_ipm_hard_ocp_qp_arg *arg)
+hpipm_size_t m_memsize_ipm_hard_ocp_qp(struct d_ocp_qp *qp, struct s_ocp_qp *s_qp, struct m_ipm_hard_ocp_qp_arg *arg)
 	{
 
 	// loop index
@@ -90,7 +90,7 @@ int m_memsize_ipm_hard_ocp_qp(struct d_ocp_qp *qp, struct s_ocp_qp *s_qp, struct
 	nbM = nb[ii]>nbM ? nb[ii] : nbM;
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (4+(N+1)*18)*sizeof(struct blasfeo_dvec); // dux dpi dt_lb dt_lg res_g res_b res_d res_d_lb res_d_ub res_d_lg res_d_ug res_m res_m_lb res_m_ub res_m_lg res_m_ug Qx_lb Qx_lg qx_lb qx_lg tmp_nbM tmp_ngM
 	size += (1+(N+1)*11)*sizeof(struct blasfeo_svec); // sdux sdpi sres_g sres_b sQx_lb sQx_lg, sqx_lb, sqx_lg tmp_nxM Pb sSx sSi

--- a/ocp_qp/x_ocp_qcqp.c
+++ b/ocp_qp/x_ocp_qcqp.c
@@ -35,14 +35,14 @@
 
 
 
-int OCP_QCQP_STRSIZE()
+hpipm_size_t OCP_QCQP_STRSIZE()
 	{
 	return sizeof(struct OCP_QCQP);
 	}
 
 
 
-int OCP_QCQP_MEMSIZE(struct OCP_QCQP_DIM *dim)
+hpipm_size_t OCP_QCQP_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	{
 
 	// extract dim
@@ -73,7 +73,7 @@ int OCP_QCQP_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	nct += 2*nb[ii]+2*ng[ii]+2*nq[ii]+2*ns[ii];
 	nqt += nq[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (N+1)*sizeof(struct STRMAT *); // Hq
 
@@ -124,7 +124,7 @@ void OCP_QCQP_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP *qp, void *mem)
 	int ii, jj;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QCQP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/ocp_qp/x_ocp_qcqp_dim.c
+++ b/ocp_qp/x_ocp_qcqp_dim.c
@@ -35,10 +35,10 @@
 
 
 
-int OCP_QCQP_DIM_STRSIZE()
+hpipm_size_t OCP_QCQP_DIM_STRSIZE()
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += sizeof(struct OCP_QCQP_DIM);
 
@@ -48,10 +48,10 @@ int OCP_QCQP_DIM_STRSIZE()
 
 
 
-int OCP_QCQP_DIM_MEMSIZE(int N)
+hpipm_size_t OCP_QCQP_DIM_MEMSIZE(int N)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 12*(N+1)*sizeof(int);
 
@@ -74,7 +74,7 @@ void OCP_QCQP_DIM_CREATE(int N, struct OCP_QCQP_DIM *dim, void *mem)
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_DIM_MEMSIZE(N);
+	hpipm_size_t memsize = OCP_QCQP_DIM_MEMSIZE(N);
 	hpipm_zero_memset(memsize, mem);
 
 	// qp_dim struct

--- a/ocp_qp/x_ocp_qcqp_ipm.c
+++ b/ocp_qp/x_ocp_qcqp_ipm.c
@@ -35,17 +35,17 @@
 
 
 
-int OCP_QCQP_IPM_ARG_STRSIZE()
+hpipm_size_t OCP_QCQP_IPM_ARG_STRSIZE()
 	{
 	return sizeof(struct OCP_QCQP_IPM_ARG);
 	}
 
 
 
-int OCP_QCQP_IPM_ARG_MEMSIZE(struct OCP_QCQP_DIM *dim)
+hpipm_size_t OCP_QCQP_IPM_ARG_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct OCP_QP_IPM_ARG);
 	size += 1*OCP_QP_IPM_ARG_MEMSIZE(dim->qp_dim);
@@ -67,7 +67,7 @@ void OCP_QCQP_IPM_ARG_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_IPM_ARG_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QCQP_IPM_ARG_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// qp_dim struct
@@ -505,14 +505,14 @@ void OCP_QCQP_IPM_ARG_SET_T_LAM_MIN(int *value, struct OCP_QCQP_IPM_ARG *arg)
 
 
 
-int OCP_QCQP_IPM_WS_STRSIZE()
+hpipm_size_t OCP_QCQP_IPM_WS_STRSIZE()
 	{
 	return sizeof(struct OCP_QCQP_IPM_WS);
 	}
 
 
 
-int OCP_QCQP_IPM_WS_MEMSIZE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *arg)
+hpipm_size_t OCP_QCQP_IPM_WS_MEMSIZE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *arg)
 	{
 
 	int N = dim->N;
@@ -529,7 +529,7 @@ int OCP_QCQP_IPM_WS_MEMSIZE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *a
 		nxM = nx[ii]>nxM ? nx[ii] : nxM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct OCP_QP_IPM_WS);
 	size += 1*OCP_QP_IPM_WS_MEMSIZE(dim->qp_dim, arg->qp_arg);
@@ -565,7 +565,7 @@ void OCP_QCQP_IPM_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *a
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = OCP_QCQP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int N = dim->N;

--- a/ocp_qp/x_ocp_qcqp_res.c
+++ b/ocp_qp/x_ocp_qcqp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int OCP_QCQP_RES_MEMSIZE(struct OCP_QCQP_DIM *dim)
+hpipm_size_t OCP_QCQP_RES_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -63,7 +63,7 @@ int OCP_QCQP_RES_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	nvt += nx[ii]+nu[ii]+2*ns[ii];
 	nct += 2*nb[ii]+2*ng[ii]+2*nq[ii]+2*ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*(N+1)*sizeof(struct STRVEC); // res_g res_d res_m
 	size += 3*N*sizeof(struct STRVEC); // res_b
@@ -88,7 +88,7 @@ void OCP_QCQP_RES_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES *res, voi
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QCQP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -216,7 +216,7 @@ void OCP_QCQP_RES_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES *res, voi
 
 
 
-int OCP_QCQP_RES_WS_MEMSIZE(struct OCP_QCQP_DIM *dim)
+hpipm_size_t OCP_QCQP_RES_WS_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -248,7 +248,7 @@ int OCP_QCQP_RES_WS_MEMSIZE(struct OCP_QCQP_DIM *dim)
 		nsM = ns[ii]>nsM ? ns[ii] : nsM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (5+2*(N+1))*sizeof(struct STRVEC); // 2*tmp_nuxM 2*tmp_nbgqM tmp_nsM q_fun q_adj
 
@@ -277,7 +277,7 @@ void OCP_QCQP_RES_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES_WS *ws
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QCQP_RES_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/ocp_qp/x_ocp_qcqp_sol.c
+++ b/ocp_qp/x_ocp_qcqp_sol.c
@@ -35,14 +35,14 @@
 
 
 
-int OCP_QCQP_SOL_STRSIZE()
+hpipm_size_t OCP_QCQP_SOL_STRSIZE()
 	{
 	return sizeof(struct OCP_QCQP_SOL);
 	}
 
 
 
-int OCP_QCQP_SOL_MEMSIZE(struct OCP_QCQP_DIM *dim)
+hpipm_size_t OCP_QCQP_SOL_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	{
 
 	// extract dim
@@ -69,7 +69,7 @@ int OCP_QCQP_SOL_MEMSIZE(struct OCP_QCQP_DIM *dim)
 	nvt += nu[ii]+nx[ii]+2*ns[ii];
 	nct += 2*nb[ii]+2*ng[ii]+2*nq[ii]+2*ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*(N+1)*sizeof(struct STRVEC); // ux lam t
 	size += 1*N*sizeof(struct STRVEC); // pi
@@ -94,7 +94,7 @@ void OCP_QCQP_SOL_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_SOL *qp_sol, 
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QCQP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QCQP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/ocp_qp/x_ocp_qp.c
+++ b/ocp_qp/x_ocp_qp.c
@@ -35,14 +35,14 @@
 
 
 
-int OCP_QP_STRSIZE()
+hpipm_size_t OCP_QP_STRSIZE()
 	{
 	return sizeof(struct OCP_QP);
 	}
 
 
 
-int OCP_QP_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	// extract dim
@@ -72,7 +72,7 @@ int OCP_QP_MEMSIZE(struct OCP_QP_DIM *dim)
 	nvt += nx[ii]+nu[ii]+2*ns[ii];
 	nct += 2*nb[ii]+2*ng[ii]+2*ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 5*(N+1)*sizeof(int); // nx nu nb ng ns
 	size += 3*(N+1)*sizeof(int *); // idxb idxs_rev idxe
@@ -121,7 +121,7 @@ void OCP_QP_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP *qp, void *mem)
 	int ii, jj;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	qp->memsize = memsize;

--- a/ocp_qp/x_ocp_qp_dim.c
+++ b/ocp_qp/x_ocp_qp_dim.c
@@ -35,17 +35,17 @@
 
 
 
-int OCP_QP_DIM_STRSIZE()
+hpipm_size_t OCP_QP_DIM_STRSIZE()
 	{
 	return sizeof(struct OCP_QP_DIM);
 	}
 
 
 
-int OCP_QP_DIM_MEMSIZE(int N)
+hpipm_size_t OCP_QP_DIM_MEMSIZE(int N)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 13*(N+1)*sizeof(int);
 
@@ -64,7 +64,7 @@ void OCP_QP_DIM_CREATE(int N, struct OCP_QP_DIM *dim, void *mem)
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_DIM_MEMSIZE(N);
+	hpipm_size_t memsize = OCP_QP_DIM_MEMSIZE(N);
 	hpipm_zero_memset(memsize, mem);
 
 	char *c_ptr = mem;

--- a/ocp_qp/x_ocp_qp_ipm.c
+++ b/ocp_qp/x_ocp_qp_ipm.c
@@ -35,14 +35,14 @@
 
 
 
-int OCP_QP_IPM_ARG_STRSIZE()
+hpipm_size_t OCP_QP_IPM_ARG_STRSIZE()
 	{
 	return sizeof(struct OCP_QP_IPM_ARG);
 	}
 
 
 
-int OCP_QP_IPM_ARG_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_IPM_ARG_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	return 0;
@@ -55,7 +55,7 @@ void OCP_QP_IPM_ARG_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg, v
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-//	int memsize = OCP_QP_IPM_ARG_MEMSIZE(dim);
+//	hpipm_size_t memsize = OCP_QP_IPM_ARG_MEMSIZE(dim);
 //	hpipm_zero_memset(memsize, mem);
 
 	arg->memsize = 0;
@@ -495,14 +495,14 @@ void OCP_QP_IPM_ARG_SET_T_LAM_MIN(int *value, struct OCP_QP_IPM_ARG *arg)
 
 
 
-int OCP_QP_IPM_WS_STRSIZE()
+hpipm_size_t OCP_QP_IPM_WS_STRSIZE()
 	{
 	return sizeof(struct OCP_QP_IPM_WS);
 	}
 
 
 
-int OCP_QP_IPM_WS_MEMSIZE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg)
+hpipm_size_t OCP_QP_IPM_WS_MEMSIZE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg)
 	{
 
 	// stat_max is at least as big as iter_max
@@ -548,7 +548,7 @@ int OCP_QP_IPM_WS_MEMSIZE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg)
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 	nsM = ns[ii]>nsM ? ns[ii] : nsM;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct CORE_QP_IPM_WORKSPACE);
 	size += 1*MEMSIZE_CORE_QP_IPM(nvt, net, nct);
@@ -635,7 +635,7 @@ void OCP_QP_IPM_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg, st
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = OCP_QP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/ocp_qp/x_ocp_qp_red.c
+++ b/ocp_qp/x_ocp_qp_red.c
@@ -76,7 +76,7 @@ void OCP_QP_DIM_REDUCE_EQ_DOF(struct OCP_QP_DIM *dim, struct OCP_QP_DIM *dim_red
 
 
 
-int OCP_QP_REDUCE_EQ_DOF_ARG_MEMSIZE()
+hpipm_size_t OCP_QP_REDUCE_EQ_DOF_ARG_MEMSIZE()
 	{
 
 	return 0;
@@ -156,7 +156,7 @@ void OCP_QP_REDUCE_EQ_DOF_ARG_SET_COMP_DUAL_SOL_INEQ(struct OCP_QP_REDUCE_EQ_DOF
 
 
 
-int OCP_QP_REDUCE_EQ_DOF_WS_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_REDUCE_EQ_DOF_WS_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	int ii;
@@ -176,7 +176,7 @@ int OCP_QP_REDUCE_EQ_DOF_WS_MEMSIZE(struct OCP_QP_DIM *dim)
 		nbgM = nb[ii]+ng[ii]>nbgM ? nb[ii]+ng[ii] : nbgM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += nuxM*sizeof(int); // e_imask_ux
 	size += nbgM*sizeof(int); // e_imask_d
@@ -201,7 +201,7 @@ void OCP_QP_REDUCE_EQ_DOF_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_REDUCE
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_REDUCE_EQ_DOF_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QP_REDUCE_EQ_DOF_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/ocp_qp/x_ocp_qp_res.c
+++ b/ocp_qp/x_ocp_qp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int OCP_QP_RES_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_RES_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	// loop index
@@ -62,7 +62,7 @@ int OCP_QP_RES_MEMSIZE(struct OCP_QP_DIM *dim)
 	nvt += nx[ii]+nu[ii]+2*ns[ii];
 	nct += 2*nb[ii]+2*ng[ii]+2*ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*(N+1)*sizeof(struct STRVEC); // res_g res_d res_m
 	size += 3*N*sizeof(struct STRVEC); // res_b
@@ -87,7 +87,7 @@ void OCP_QP_RES_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES *res, void *mem
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -210,7 +210,7 @@ void OCP_QP_RES_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES *res, void *mem
 
 
 
-int OCP_QP_RES_WS_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_RES_WS_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	// loop index
@@ -238,7 +238,7 @@ int OCP_QP_RES_WS_MEMSIZE(struct OCP_QP_DIM *dim)
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 	nsM = ns[ii]>nsM ? ns[ii] : nsM;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*sizeof(struct STRVEC); // 2*tmp_nbgM tmp_nsM
 
@@ -261,7 +261,7 @@ void OCP_QP_RES_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES_WS *ws, void
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QP_RES_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/ocp_qp/x_ocp_qp_sol.c
+++ b/ocp_qp/x_ocp_qp_sol.c
@@ -35,14 +35,14 @@
 
 
 
-int OCP_QP_SOL_STRSIZE()
+hpipm_size_t OCP_QP_SOL_STRSIZE()
 	{
 	return sizeof(struct OCP_QP_SOL);
 	}
 
 
 
-int OCP_QP_SOL_MEMSIZE(struct OCP_QP_DIM *dim)
+hpipm_size_t OCP_QP_SOL_MEMSIZE(struct OCP_QP_DIM *dim)
 	{
 
 	// extract dim
@@ -68,7 +68,7 @@ int OCP_QP_SOL_MEMSIZE(struct OCP_QP_DIM *dim)
 	nvt += nu[ii]+nx[ii]+2*ns[ii];
 	nct += 2*nb[ii]+2*ng[ii]+2*ns[ii];
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*(N+1)*sizeof(struct STRVEC); // ux lam t
 	size += 1*N*sizeof(struct STRVEC); // pi
@@ -93,7 +93,7 @@ void OCP_QP_SOL_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_SOL *qp_sol, void *
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = OCP_QP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = OCP_QP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/sim_core/x_sim_erk.c
+++ b/sim_core/x_sim_erk.c
@@ -35,7 +35,7 @@
 
 
 
-int SIM_ERK_ARG_MEMSIZE()
+hpipm_size_t SIM_ERK_ARG_MEMSIZE()
 	{
 	return 0;
 	}
@@ -46,7 +46,7 @@ void SIM_ERK_ARG_CREATE(struct SIM_ERK_ARG *erk_arg, void *mem)
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = SIM_ERK_ARG_MEMSIZE();
+	hpipm_size_t memsize = SIM_ERK_ARG_MEMSIZE();
 	hpipm_zero_memset(memsize, mem);
 
 	erk_arg->memsize = memsize;
@@ -72,7 +72,7 @@ void SIM_ERK_ARG_SET_ALL(struct SIM_RK_DATA *rk_data, REAL h, int steps, struct 
 
 
 
-int SIM_ERK_WS_MEMSIZE(struct SIM_ERK_ARG *erk_arg, int nx, int np, int nf_max, int na_max)
+hpipm_size_t SIM_ERK_WS_MEMSIZE(struct SIM_ERK_ARG *erk_arg, int nx, int np, int nf_max, int na_max)
 	{
 
 	int ns = erk_arg->rk_data->ns;
@@ -81,7 +81,7 @@ int SIM_ERK_WS_MEMSIZE(struct SIM_ERK_ARG *erk_arg, int nx, int np, int nf_max, 
 
 	int steps = erk_arg->steps;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*np*sizeof(REAL); // p
 	size += 1*nX*sizeof(REAL); // x_for
@@ -108,7 +108,7 @@ void SIM_ERK_WS_CREATE(struct SIM_ERK_ARG *erk_arg, int nx, int np, int nf_max, 
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = SIM_ERK_WS_MEMSIZE(erk_arg, nx, np, nf_max, na_max);
+	hpipm_size_t memsize = SIM_ERK_WS_MEMSIZE(erk_arg, nx, np, nf_max, na_max);
 	hpipm_zero_memset(memsize, mem);
 
 	work->erk_arg = erk_arg;

--- a/sim_core/x_sim_rk.c
+++ b/sim_core/x_sim_rk.c
@@ -35,10 +35,10 @@
 
 
 
-int SIM_RK_DATA_MEMSIZE(int ns)
+hpipm_size_t SIM_RK_DATA_MEMSIZE(int ns)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*ns*ns*sizeof(REAL); // A
 	size += 2*ns*sizeof(REAL); // B C

--- a/test_problems/test_d_cast_qcqp.c
+++ b/test_problems/test_d_cast_qcqp.c
@@ -709,7 +709,7 @@ int main()
 * ocp qcqp dim
 ************************************************/
 
-	int dim_size = d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qcqp_dim_memsize(N);
 	printf("\ndim size = %d\n", dim_size);
 	void *dim_mem = malloc(dim_size);
 
@@ -732,7 +732,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qcqp_size = d_ocp_qcqp_memsize(&dim);
+	hpipm_size_t qcqp_size = d_ocp_qcqp_memsize(&dim);
 	printf("\nqp size = %d\n", qcqp_size);
 	void *qcqp_mem = malloc(qcqp_size);
 
@@ -824,7 +824,7 @@ int main()
 * dense qp dim
 ************************************************/
 
-	int dense_dim_size = d_dense_qcqp_dim_memsize();
+	hpipm_size_t dense_dim_size = d_dense_qcqp_dim_memsize();
 	printf("\ndense dim size = %d\n", dense_dim_size);
 	void *dense_dim_mem = malloc(dense_dim_size);
 
@@ -840,7 +840,7 @@ int main()
 ************************************************/
 
 	// qp
-	int dense_qp_size = d_dense_qcqp_memsize(&dense_dim);
+	hpipm_size_t dense_qp_size = d_dense_qcqp_memsize(&dense_dim);
 	printf("\nqp size = %d\n", dense_qp_size);
 	void *dense_qp_mem = malloc(dense_qp_size);
 
@@ -855,7 +855,7 @@ int main()
 * dense qp sol
 ************************************************/
 
-	int dense_qp_sol_size = d_dense_qcqp_sol_memsize(&dense_dim);
+	hpipm_size_t dense_qp_sol_size = d_dense_qcqp_sol_memsize(&dense_dim);
 	printf("\ndense qp sol size = %d\n", dense_qp_sol_size);
 	void *dense_qp_sol_mem = malloc(dense_qp_sol_size);
 
@@ -866,7 +866,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&dense_dim);
+	hpipm_size_t ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&dense_dim);
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
@@ -888,7 +888,7 @@ int main()
 * ipm
 ************************************************/
 
-	int dense_ipm_size = d_dense_qcqp_ipm_ws_memsize(&dense_dim, &dense_arg);
+	hpipm_size_t dense_ipm_size = d_dense_qcqp_ipm_ws_memsize(&dense_dim, &dense_arg);
 	printf("\ndense ipm size = %d\n", dense_ipm_size);
 	void *dense_ipm_mem = malloc(dense_ipm_size);
 

--- a/test_problems/test_d_cond.c
+++ b/test_problems/test_d_cond.c
@@ -690,9 +690,9 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 #if PRINT
-	printf("\ndim size = %d\n", dim_size);
+	printf("\ndim size = %u\n", (unsigned int)dim_size);
 #endif
 	void *dim_mem = malloc(dim_size);
 
@@ -704,9 +704,9 @@ int main()
 * ocp qp
 ************************************************/
 
-	int ocp_qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t ocp_qp_size = d_ocp_qp_memsize(&dim);
 #if PRINT
-	printf("\nqp size = %d\n", ocp_qp_size);
+	printf("\nqp size = %u\n", (unsigned int)ocp_qp_size);
 #endif
 	void *ocp_qp_mem = malloc(ocp_qp_size);
 
@@ -742,9 +742,9 @@ int main()
 * dense qp dim
 ************************************************/
 
-	int dense_qp_dim_size = d_dense_qp_dim_memsize();
+	hpipm_size_t dense_qp_dim_size = d_dense_qp_dim_memsize();
 #if PRINT
-	printf("\nqp dim size = %d\n", dense_qp_dim_size);
+	printf("\nqp dim size = %u\n", (unsigned int)dense_qp_dim_size);
 #endif
 	void *dense_qp_dim_mem = malloc(dense_qp_dim_size);
 
@@ -770,9 +770,9 @@ int main()
 ************************************************/
 
 	// qp
-	int dense_qp_size = d_dense_qp_memsize(&qp_dim);
+	hpipm_size_t dense_qp_size = d_dense_qp_memsize(&qp_dim);
 #if PRINT
-	printf("\nqp size = %d\n", dense_qp_size);
+	printf("\nqp size = %u\n", (unsigned int)dense_qp_size);
 #endif
 	void *dense_qp_mem = malloc(dense_qp_size);
 
@@ -780,9 +780,9 @@ int main()
 	d_dense_qp_create(&qp_dim, &dense_qp, dense_qp_mem);
 
 	// arg
-	int cond_arg_size = d_cond_qp_arg_memsize();
+	hpipm_size_t cond_arg_size = d_cond_qp_arg_memsize();
 #if PRINT
-	printf("\ncond_arg size = %d\n", cond_arg_size);
+	printf("\ncond_arg size = %u\n", (unsigned int)cond_arg_size);
 #endif
 	void *cond_arg_mem = malloc(cond_arg_size);
 
@@ -791,9 +791,9 @@ int main()
 	d_cond_qp_arg_set_default(&cond_arg);
 
 	// ws
-	int cond_size = d_cond_qp_ws_memsize(&dim, &cond_arg);
+	hpipm_size_t cond_size = d_cond_qp_ws_memsize(&dim, &cond_arg);
 #if PRINT
-	printf("\ncond size = %d\n", cond_size);
+	printf("\ncond size = %u\n", (unsigned int)cond_size);
 #endif
 	void *cond_mem = malloc(cond_size);
 
@@ -894,9 +894,9 @@ int main()
 * dense qp sol
 ************************************************/
 
-	int dense_qp_sol_size = d_dense_qp_sol_memsize(&qp_dim);
+	hpipm_size_t dense_qp_sol_size = d_dense_qp_sol_memsize(&qp_dim);
 #if PRINT
-	printf("\ndense qp sol size = %d\n", dense_qp_sol_size);
+	printf("\ndense qp sol size = %u\n", (unsigned int)dense_qp_sol_size);
 #endif
 	void *dense_qp_sol_mem = malloc(dense_qp_sol_size);
 
@@ -907,9 +907,9 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_dense_qp_ipm_arg_memsize(&qp_dim);
+	hpipm_size_t ipm_arg_size = d_dense_qp_ipm_arg_memsize(&qp_dim);
 #if PRINT
-	printf("\nipm arg size = %d\n", ipm_arg_size);
+	printf("\nipm arg size = %u\n", (unsigned int)ipm_arg_size);
 #endif
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
@@ -935,9 +935,9 @@ int main()
 * ipm
 ************************************************/
 
-	int dense_ipm_size = d_dense_qp_ipm_ws_memsize(&qp_dim, &dense_arg);
+	hpipm_size_t dense_ipm_size = d_dense_qp_ipm_ws_memsize(&qp_dim, &dense_arg);
 #if PRINT
-	printf("\ndense ipm size = %d\n", dense_ipm_size);
+	printf("\ndense ipm size = %u\n", (unsigned int)dense_ipm_size);
 #endif
 	void *dense_ipm_mem = malloc(dense_ipm_size);
 
@@ -1037,9 +1037,9 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int ocp_qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t ocp_qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 #if PRINT
-	printf("\nocp qp sol size = %d\n", ocp_qp_sol_size);
+	printf("\nocp qp sol size = %d\n", (unsigned int)ocp_qp_sol_size);
 #endif
 	void *ocp_qp_sol_mem = malloc(ocp_qp_sol_size);
 

--- a/test_problems/test_d_cond_qcqp.c
+++ b/test_problems/test_d_cond_qcqp.c
@@ -635,7 +635,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int ocp_dim_size = d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t ocp_dim_size = d_ocp_qcqp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", ocp_dim_size);
 #endif
@@ -667,7 +667,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int ocp_qp_size = d_ocp_qcqp_memsize(&ocp_dim);
+	hpipm_size_t ocp_qp_size = d_ocp_qcqp_memsize(&ocp_dim);
 #if PRINT
 	printf("\nqp size = %d\n", ocp_qp_size);
 #endif
@@ -790,7 +790,7 @@ int main()
 * dense qp dim
 ************************************************/
 
-	int dense_dim_size = d_dense_qcqp_dim_memsize();
+	hpipm_size_t dense_dim_size = d_dense_qcqp_dim_memsize();
 #if PRINT
 	printf("\ndense dim size = %d\n", dense_dim_size);
 #endif
@@ -810,7 +810,7 @@ int main()
 ************************************************/
 
 	// qp
-	int dense_qp_size = d_dense_qcqp_memsize(&dense_dim);
+	hpipm_size_t dense_qp_size = d_dense_qcqp_memsize(&dense_dim);
 #if PRINT
 	printf("\nqp size = %d\n", dense_qp_size);
 #endif
@@ -820,7 +820,7 @@ int main()
 	d_dense_qcqp_create(&dense_dim, &dense_qp, dense_qp_mem);
 
 	// arg
-	int cond_arg_size = d_cond_qcqp_arg_memsize();
+	hpipm_size_t cond_arg_size = d_cond_qcqp_arg_memsize();
 #if PRINT
 	printf("\ncond_arg size = %d\n", cond_arg_size);
 #endif
@@ -831,7 +831,7 @@ int main()
 	d_cond_qcqp_arg_set_default(&cond_arg);
 
 	// ws
-	int cond_size = d_cond_qcqp_ws_memsize(&ocp_dim, &cond_arg);
+	hpipm_size_t cond_size = d_cond_qcqp_ws_memsize(&ocp_dim, &cond_arg);
 #if PRINT
 	printf("\ncond size = %d\n", cond_size);
 #endif
@@ -894,7 +894,7 @@ int main()
 * dense qp sol
 ************************************************/
 
-	int dense_qp_sol_size = d_dense_qcqp_sol_memsize(&dense_dim);
+	hpipm_size_t dense_qp_sol_size = d_dense_qcqp_sol_memsize(&dense_dim);
 #if PRINT
 	printf("\ndense qp sol size = %d\n", dense_qp_sol_size);
 #endif
@@ -907,7 +907,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&dense_dim);
+	hpipm_size_t ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&dense_dim);
 #if PRINT
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 #endif
@@ -935,7 +935,7 @@ int main()
 * ipm
 ************************************************/
 
-	int dense_ipm_size = d_dense_qcqp_ipm_ws_memsize(&dense_dim, &dense_arg);
+	hpipm_size_t dense_ipm_size = d_dense_qcqp_ipm_ws_memsize(&dense_dim, &dense_arg);
 #if PRINT
 	printf("\ndense ipm size = %d\n", dense_ipm_size);
 #endif
@@ -993,7 +993,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int ocp_qp_sol_size = d_ocp_qcqp_sol_memsize(&ocp_dim);
+	hpipm_size_t ocp_qp_sol_size = d_ocp_qcqp_sol_memsize(&ocp_dim);
 #if PRINT
 	printf("\nocp qp sol size = %d\n", ocp_qp_sol_size);
 #endif

--- a/test_problems/test_d_dense.c
+++ b/test_problems/test_d_dense.c
@@ -275,7 +275,7 @@ int main()
 * dense qp dim
 ************************************************/
 
-	int dense_qp_dim_size = d_dense_qp_dim_memsize();
+	hpipm_size_t dense_qp_dim_size = d_dense_qp_dim_memsize();
 #if PRINT
 	printf("\nqp dim size = %d\n", dense_qp_dim_size);
 #endif
@@ -290,7 +290,7 @@ int main()
 * dense qp
 ************************************************/
 
-	int qp_size = d_dense_qp_memsize(&qp_dim);
+	hpipm_size_t qp_size = d_dense_qp_memsize(&qp_dim);
 #if PRINT
 	printf("\nqp size = %d\n", qp_size);
 #endif
@@ -351,7 +351,7 @@ int main()
 * dense qp sol
 ************************************************/
 
-	int qp_sol_size = d_dense_qp_sol_memsize(&qp_dim);
+	hpipm_size_t qp_sol_size = d_dense_qp_sol_memsize(&qp_dim);
 #if PRINT
 	printf("\nqp sol size = %d\n", qp_sol_size);
 #endif
@@ -364,7 +364,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_dense_qp_ipm_arg_memsize(&qp_dim);
+	hpipm_size_t ipm_arg_size = d_dense_qp_ipm_arg_memsize(&qp_dim);
 #if PRINT
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 #endif
@@ -415,7 +415,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_dense_qp_ipm_ws_memsize(&qp_dim, &arg);
+	hpipm_size_t ipm_size = d_dense_qp_ipm_ws_memsize(&qp_dim, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_d_dense_qcqp.c
+++ b/test_problems/test_d_dense_qcqp.c
@@ -102,7 +102,7 @@ int main()
 * dense qp dim
 ************************************************/
 
-	int dense_qcqp_dim_size = d_dense_qcqp_dim_memsize();
+	hpipm_size_t dense_qcqp_dim_size = d_dense_qcqp_dim_memsize();
 #if PRINT
 	printf("\nqp dim size = %d\n", dense_qcqp_dim_size);
 #endif
@@ -128,7 +128,7 @@ int main()
 * dense qp
 ************************************************/
 
-	int qp_size = d_dense_qcqp_memsize(&qcqp_dim);
+	hpipm_size_t qp_size = d_dense_qcqp_memsize(&qcqp_dim);
 #if PRINT
 	printf("\nqp size = %d\n", qp_size);
 #endif
@@ -166,7 +166,7 @@ int main()
 * dense qp sol
 ************************************************/
 
-	int qp_sol_size = d_dense_qcqp_sol_memsize(&qcqp_dim);
+	hpipm_size_t qp_sol_size = d_dense_qcqp_sol_memsize(&qcqp_dim);
 #if PRINT
 	printf("\nqp sol size = %d\n", qp_sol_size);
 #endif
@@ -184,7 +184,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&qcqp_dim);
+	hpipm_size_t ipm_arg_size = d_dense_qcqp_ipm_arg_memsize(&qcqp_dim);
 #if PRINT
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 #endif
@@ -232,7 +232,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_dense_qcqp_ipm_ws_memsize(&qcqp_dim, &arg);
+	hpipm_size_t ipm_size = d_dense_qcqp_ipm_ws_memsize(&qcqp_dim, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_d_ocp.c
+++ b/test_problems/test_d_ocp.c
@@ -787,7 +787,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size);
 #endif
@@ -808,7 +808,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 #if PRINT
 	printf("\nqp size = %d\n", qp_size);
 #endif
@@ -875,7 +875,7 @@ int main()
 
 #else // keep x0
 
-	int dim_size2 = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size2 = d_ocp_qp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size2);
 #endif
@@ -891,7 +891,7 @@ int main()
 #endif
 
 
-	int qp_size2 = d_ocp_qp_memsize(&dim2);
+	hpipm_size_t qp_size2 = d_ocp_qp_memsize(&dim2);
 #if PRINT
 	printf("\nqp size = %d\n", qp_size2);
 #endif
@@ -903,7 +903,7 @@ int main()
 //	d_ocp_qp_print(qp2.dim, &qp2);
 
 
-	int qp_red_arg_size = d_ocp_qp_reduce_eq_dof_arg_memsize();
+	hpipm_size_t qp_red_arg_size = d_ocp_qp_reduce_eq_dof_arg_memsize();
 #if PRINT
 	printf("\nqp red arg size = %d\n", qp_red_arg_size);
 #endif
@@ -918,7 +918,7 @@ int main()
 	d_ocp_qp_reduce_eq_dof_arg_set_comp_dual_sol_ineq(&qp_red_arg, 1);
 
 
-	int qp_red_work_size = d_ocp_qp_reduce_eq_dof_ws_memsize(&dim);
+	hpipm_size_t qp_red_work_size = d_ocp_qp_reduce_eq_dof_ws_memsize(&dim);
 #if PRINT
 	printf("\nqp red work size = %d\n", qp_red_work_size);
 #endif
@@ -947,7 +947,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 #if PRINT
 	printf("\nqp sol size = %d\n", qp_sol_size);
 #endif
@@ -962,7 +962,7 @@ int main()
 
 #else // keep x0
 
-	int qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
+	hpipm_size_t qp_sol_size2 = d_ocp_qp_sol_memsize(&dim2);
 #if PRINT
 	printf("\nqp sol size = %d\n", qp_sol_size2);
 #endif
@@ -977,7 +977,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim2);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim2);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -1024,7 +1024,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_d_ocp2.c
+++ b/test_problems/test_d_ocp2.c
@@ -746,7 +746,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_memsize_ocp_qp(N, nx, nu, nb, ng, ns);
+	hpipm_size_t qp_size = d_memsize_ocp_qp(N, nx, nu, nb, ng, ns);
 	printf("\nqp size = %d\n", qp_size);
 	void *qp_mem = malloc(qp_size);
 
@@ -782,7 +782,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_memsize_ocp_qp_sol(N, nx, nu, nb, ng, ns);
+	hpipm_size_t qp_sol_size = d_memsize_ocp_qp_sol(N, nx, nu, nb, ng, ns);
 	printf("\nqp sol size = %d\n", qp_sol_size);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
@@ -799,7 +799,7 @@ int main()
 	arg.iter_max = 20;
 	arg.mu0 = 100.0;
 
-	int ipm_size = d_memsize_ipm_ocp_qp(&qp, &arg);
+	hpipm_size_t ipm_size = d_memsize_ipm_ocp_qp(&qp, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *ipm_mem = malloc(ipm_size);
 

--- a/test_problems/test_d_ocp_phase_I.c
+++ b/test_problems/test_d_ocp_phase_I.c
@@ -792,7 +792,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 	printf("\ndim size = %d\n", dim_size);
 	void *dim_mem = malloc(dim_size);
 
@@ -804,7 +804,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t qp_size = d_ocp_qp_memsize(&dim);
 	printf("\nqp size = %d\n", qp_size);
 	void *qp_mem = malloc(qp_size);
 
@@ -841,7 +841,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 	printf("\nqp sol size = %d\n", qp_sol_size);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
@@ -852,7 +852,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -891,7 +891,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *ipm_mem = malloc(ipm_size);
 

--- a/test_problems/test_d_ocp_qcqp.c
+++ b/test_problems/test_d_ocp_qcqp.c
@@ -735,7 +735,7 @@ int main()
 * ocp qcqp dim
 ************************************************/
 
-	int dim_size = d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qcqp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size);
 #endif
@@ -762,7 +762,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int qcqp_size = d_ocp_qcqp_memsize(&dim);
+	hpipm_size_t qcqp_size = d_ocp_qcqp_memsize(&dim);
 #if PRINT
 	printf("\nqp size = %d\n", qcqp_size);
 #endif
@@ -886,7 +886,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int qcqp_sol_size = d_ocp_qcqp_sol_memsize(&dim);
+	hpipm_size_t qcqp_sol_size = d_ocp_qcqp_sol_memsize(&dim);
 #if PRINT
 	printf("\nqcqp sol size = %d\n", qcqp_sol_size);
 #endif
@@ -899,7 +899,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&dim);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qcqp_ipm_arg arg;
@@ -941,7 +941,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_ocp_qcqp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_ocp_qcqp_ipm_ws_memsize(&dim, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_d_part_cond.c
+++ b/test_problems/test_d_part_cond.c
@@ -687,7 +687,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int dim_size = d_ocp_qp_dim_memsize(N);
+	hpipm_size_t dim_size = d_ocp_qp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size);
 #endif
@@ -701,7 +701,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int ocp_qp_size = d_ocp_qp_memsize(&dim);
+	hpipm_size_t ocp_qp_size = d_ocp_qp_memsize(&dim);
 #if PRINT
 	printf("\nocp qp size = %d\n", ocp_qp_size);
 #endif
@@ -752,7 +752,7 @@ int main()
 	int nsbu2[N2+1];
 	int nsg2[N2+1];
 
-	int dim_size2 = d_ocp_qp_dim_memsize(N2);
+	hpipm_size_t dim_size2 = d_ocp_qp_dim_memsize(N2);
 #if PRINT
 	printf("\ndim size2 = %d\n", dim_size2);
 #endif
@@ -766,7 +766,7 @@ int main()
 * part dense qp
 ************************************************/
 
-	int block_size[N2+1];
+	hpipm_size_t block_size[N2+1];
 #if 1
 	d_part_cond_qp_compute_block_size(N, N2, block_size);
 #else
@@ -806,7 +806,7 @@ int main()
 #endif
 
 	// qp
-	int part_dense_qp_size = d_ocp_qp_memsize(&dim2);
+	hpipm_size_t part_dense_qp_size = d_ocp_qp_memsize(&dim2);
 #if PRINT
 	printf("\npart dense qp size = %d\n", part_dense_qp_size);
 #endif
@@ -816,7 +816,7 @@ int main()
 	d_ocp_qp_create(&dim2, &part_dense_qp, part_dense_qp_mem);
 
 	// arg
-	int part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
+	hpipm_size_t part_cond_arg_size = d_part_cond_qp_arg_memsize(dim2.N);
 #if PRINT
 	printf("\npart cond_arg size = %d\n", part_cond_arg_size);
 #endif
@@ -830,7 +830,7 @@ int main()
 //		part_cond_arg.cond_arg[ii].square_root_alg = 0;
 
 	// ws
-	int part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
+	hpipm_size_t part_cond_size = d_part_cond_qp_ws_memsize(&dim, block_size, &dim2, &part_cond_arg);
 #if PRINT
 	printf("\npart cond size = %d\n", part_cond_size);
 #endif
@@ -930,7 +930,7 @@ int main()
 * part dense qp sol
 ************************************************/
 
-	int part_dense_qp_sol_size = d_ocp_qp_sol_memsize(&dim2);
+	hpipm_size_t part_dense_qp_sol_size = d_ocp_qp_sol_memsize(&dim2);
 #if PRINT
 	printf("\npart dense qp sol size = %d\n", part_dense_qp_sol_size);
 #endif
@@ -943,7 +943,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim2);
+	hpipm_size_t ipm_arg_size = d_ocp_qp_ipm_arg_memsize(&dim2);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qp_ipm_arg arg;
@@ -982,7 +982,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qp_ipm_ws_memsize(&dim2, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif
@@ -1189,7 +1189,7 @@ int main()
 * full space ocp qp sol
 ************************************************/
 
-	int ocp_qp_sol_size = d_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t ocp_qp_sol_size = d_ocp_qp_sol_memsize(&dim);
 #if PRINT
 	printf("\nocp qp sol size = %d\n", ocp_qp_sol_size);
 #endif

--- a/test_problems/test_d_part_cond_qcqp.c
+++ b/test_problems/test_d_part_cond_qcqp.c
@@ -636,7 +636,7 @@ int main()
 * ocp qp dim
 ************************************************/
 
-	int ocp_dim_size = d_ocp_qcqp_dim_memsize(N);
+	hpipm_size_t ocp_dim_size = d_ocp_qcqp_dim_memsize(N);
 #if PRINT
 	printf("\ndim size = %d\n", ocp_dim_size);
 #endif
@@ -668,7 +668,7 @@ int main()
 * ocp qp
 ************************************************/
 
-	int ocp_qp_size = d_ocp_qcqp_memsize(&ocp_dim);
+	hpipm_size_t ocp_qp_size = d_ocp_qcqp_memsize(&ocp_dim);
 #if PRINT
 	printf("\nqp size = %d\n", ocp_qp_size);
 #endif
@@ -793,7 +793,7 @@ int main()
 
 	int N2 = 2; // horizon of partially condensed problem
 
-	int ocp_dim_size2 = d_ocp_qcqp_dim_memsize(N2);
+	hpipm_size_t ocp_dim_size2 = d_ocp_qcqp_dim_memsize(N2);
 #if PRINT
 	printf("\ndim size2 = %d\n", ocp_dim_size2);
 #endif
@@ -802,7 +802,7 @@ int main()
 	struct d_ocp_qcqp_dim ocp_dim2;
 	d_ocp_qcqp_dim_create(N2, &ocp_dim2, ocp_dim_mem2);
 
-	int block_size[N2+1];
+	hpipm_size_t block_size[N2+1];
 #if 1
 	d_part_cond_qcqp_compute_block_size(N, N2, block_size);
 #else
@@ -826,7 +826,7 @@ int main()
 ************************************************/
 
 	// qp
-	int ocp_qp_size2 = d_ocp_qcqp_memsize(&ocp_dim2);
+	hpipm_size_t ocp_qp_size2 = d_ocp_qcqp_memsize(&ocp_dim2);
 #if PRINT
 	printf("\npart dense qp size = %d\n", ocp_qp_size2);
 #endif
@@ -836,7 +836,7 @@ int main()
 	d_ocp_qcqp_create(&ocp_dim2, &ocp_qp2, ocp_qp_mem2);
 
 	// arg
-	int part_cond_arg_size = d_part_cond_qcqp_arg_memsize(ocp_dim2.N);
+	hpipm_size_t part_cond_arg_size = d_part_cond_qcqp_arg_memsize(ocp_dim2.N);
 #if PRINT
 	printf("\npart cond_arg size = %d\n", part_cond_arg_size);
 #endif
@@ -850,7 +850,7 @@ int main()
 //		part_cond_arg.cond_arg[ii].square_root_alg = 0;
 
 	// ws
-	int part_cond_size = d_part_cond_qcqp_ws_memsize(&ocp_dim, block_size, &ocp_dim2, &part_cond_arg);
+	hpipm_size_t part_cond_size = d_part_cond_qcqp_ws_memsize(&ocp_dim, block_size, &ocp_dim2, &part_cond_arg);
 #if PRINT
 	printf("\npart cond size = %d\n", part_cond_size);
 #endif
@@ -906,7 +906,7 @@ int main()
 * part dense qp sol
 ************************************************/
 
-	int ocp_qp_sol_size2 = d_ocp_qcqp_sol_memsize(&ocp_dim2);
+	hpipm_size_t ocp_qp_sol_size2 = d_ocp_qcqp_sol_memsize(&ocp_dim2);
 #if PRINT
 	printf("\npart dense qp sol size = %d\n", ocp_qp_sol_size2);
 #endif
@@ -919,7 +919,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&ocp_dim2);
+	hpipm_size_t ipm_arg_size = d_ocp_qcqp_ipm_arg_memsize(&ocp_dim2);
 	void *ipm_arg_mem = malloc(ipm_arg_size);
 
 	struct d_ocp_qcqp_ipm_arg arg;
@@ -959,7 +959,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_ocp_qcqp_ipm_ws_memsize(&ocp_dim2, &arg);
+	hpipm_size_t ipm_size = d_ocp_qcqp_ipm_ws_memsize(&ocp_dim2, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif
@@ -1017,7 +1017,7 @@ int main()
 * full space ocp qp sol
 ************************************************/
 
-	int ocp_qp_sol_size = d_ocp_qcqp_sol_memsize(&ocp_dim);
+	hpipm_size_t ocp_qp_sol_size = d_ocp_qcqp_sol_memsize(&ocp_dim);
 #if PRINT
 	printf("\nocp qp sol size = %d\n", ocp_qp_sol_size);
 #endif

--- a/test_problems/test_d_sim.c
+++ b/test_problems/test_d_sim.c
@@ -199,14 +199,14 @@ struct d_linear_system
 	double *Bc;
 	int nx;
 	int nu;
-	int memsize;
+	hpipm_size_t memsize;
 	};
 
 
 
-int d_linear_system_memsize(int nx, int nu)
+hpipm_size_t d_linear_system_memsize(int nx, int nu)
 	{
-	int size = 0;
+	hpipm_size_t size = 0;
 	size += (nx*nx+nx*nu)*sizeof(double);
 	return size;
 	}
@@ -388,7 +388,7 @@ int main()
 	d_print_mat(nx, nx, Ac, nx);
 	d_print_mat(nx, nu, Bc, nx);
 
-	int ls_memsize = d_linear_system_memsize(nx, nu);
+	hpipm_size_t ls_memsize = d_linear_system_memsize(nx, nu);
 	printf("\nls memsize = %d\n", ls_memsize);
 	void *ls_memory = malloc(ls_memsize);
 
@@ -491,7 +491,7 @@ int main()
 #endif
 //	printf("\n%d %s\n", ns, rk_method);
 
-	int size_rk_data = d_sim_rk_data_memsize(ns);
+	hpipm_size_t size_rk_data = d_sim_rk_data_memsize(ns);
 	printf("\nmemsize rk data %d\n", size_rk_data);
 	void *mem_rk_data = malloc(size_rk_data);
 
@@ -503,7 +503,7 @@ int main()
 //	d_print_mat(ns, ns, rk_data.A_rk, ns);
 
 	
-	int size_erk_arg = d_sim_erk_arg_memsize();
+	hpipm_size_t size_erk_arg = d_sim_erk_arg_memsize();
 	printf("\nmemsize erk arg %d\n", size_erk_arg);
 	void *mem_erk_arg = malloc(size_erk_arg);
 
@@ -515,7 +515,7 @@ int main()
 
 	int nf_max = nu+nx;
 	int na_max = 0;
-	int size_erk_ws = d_sim_erk_ws_memsize(&erk_arg, nx, nu, nf_max, na_max);
+	hpipm_size_t size_erk_ws = d_sim_erk_ws_memsize(&erk_arg, nx, nu, nf_max, na_max);
 	printf("\nmemsize erk ws %d\n", size_erk_ws);
 	void *mem_erk_ws = malloc(size_erk_ws);
 
@@ -580,7 +580,7 @@ int main()
 	int nf = nx+nu;
 	int np = nu;
 
-	int memsize_erk_int = d_memsize_erk_int(&rk_data, nx, nf, np);
+	hpipm_size_t memsize_erk_int = d_memsize_erk_int(&rk_data, nx, nf, np);
 	printf("\nmemsize erk int %d\n", memsize_erk_int);
 	void *memory_erk = malloc(memsize_erk_int);
 
@@ -644,7 +644,7 @@ int main()
 * implicit integrator
 ************************************************/	
 	
-	int memsize_irk_int = d_memsize_irk_int(&rk_data, nx, nf, np);
+	hpipm_size_t memsize_irk_int = d_memsize_irk_int(&rk_data, nx, nf, np);
 	printf("\nmemsize irk int %d\n", memsize_irk_int);
 	void *memory_irk = malloc(memsize_irk_int);
 

--- a/test_problems/test_d_tree_ocp.c
+++ b/test_problems/test_d_tree_ocp.c
@@ -617,7 +617,7 @@ int main()
 * create scenario tree
 ************************************************/
 
-	int tree_memsize = sctree_memsize(md, Nr, Nh);
+	hpipm_size_t tree_memsize = sctree_memsize(md, Nr, Nh);
 #if PRINT
 	printf("\ntree memsize = %d\n", tree_memsize);
 #endif
@@ -868,7 +868,7 @@ int main()
 * create tree ocp qp dim
 ************************************************/
 
-	int dim_size = d_tree_ocp_qp_dim_memsize(Nn);
+	hpipm_size_t dim_size = d_tree_ocp_qp_dim_memsize(Nn);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size);
 #endif
@@ -882,7 +882,7 @@ int main()
 * create tree ocp qp
 ************************************************/
 
-	int tree_ocp_qp_memsize = d_tree_ocp_qp_memsize(&dim);
+	hpipm_size_t tree_ocp_qp_memsize = d_tree_ocp_qp_memsize(&dim);
 #if PRINT
 	printf("\ntree ocp qp memsize = %d\n", tree_ocp_qp_memsize);
 #endif
@@ -931,7 +931,7 @@ exit(1);
 * ocp qp sol
 ************************************************/
 
-	int tree_ocp_qp_sol_size = d_tree_ocp_qp_sol_memsize(&dim);
+	hpipm_size_t tree_ocp_qp_sol_size = d_tree_ocp_qp_sol_memsize(&dim);
 #if PRINT
 	printf("\ntree ocp qp sol memsize = %d\n", tree_ocp_qp_sol_size);
 #endif
@@ -944,7 +944,7 @@ exit(1);
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_tree_ocp_qp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_tree_ocp_qp_ipm_arg_memsize(&dim);
 #if PRINT
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 #endif
@@ -972,7 +972,7 @@ exit(1);
 * ipm
 ************************************************/
 
-	int ipm_size = d_tree_ocp_qp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_tree_ocp_qp_ipm_ws_memsize(&dim, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_d_tree_ocp_qcqp.c
+++ b/test_problems/test_d_tree_ocp_qcqp.c
@@ -707,7 +707,7 @@ int main()
 * create scenario tree
 ************************************************/
 
-	int tree_memsize = sctree_memsize(md, Nr, Nh);
+	hpipm_size_t tree_memsize = sctree_memsize(md, Nr, Nh);
 #if PRINT
 	printf("\ntree memsize = %d\n", tree_memsize);
 #endif
@@ -938,7 +938,7 @@ int main()
 * create tree ocp qp dim
 ************************************************/
 
-	int dim_size = d_tree_ocp_qcqp_dim_memsize(Nn);
+	hpipm_size_t dim_size = d_tree_ocp_qcqp_dim_memsize(Nn);
 #if PRINT
 	printf("\ndim size = %d\n", dim_size);
 #endif
@@ -973,7 +973,7 @@ int main()
 * create tree ocp qp
 ************************************************/
 
-	int tree_ocp_qp_memsize = d_tree_ocp_qcqp_memsize(&dim);
+	hpipm_size_t tree_ocp_qp_memsize = d_tree_ocp_qcqp_memsize(&dim);
 #if PRINT
 	printf("\ntree ocp qp memsize = %d\n", tree_ocp_qp_memsize);
 #endif
@@ -1039,7 +1039,7 @@ int main()
 * ocp qp sol
 ************************************************/
 
-	int tree_ocp_qp_sol_size = d_tree_ocp_qcqp_sol_memsize(&dim);
+	hpipm_size_t tree_ocp_qp_sol_size = d_tree_ocp_qcqp_sol_memsize(&dim);
 #if PRINT
 	printf("\ntree ocp qp sol memsize = %d\n", tree_ocp_qp_sol_size);
 #endif
@@ -1052,7 +1052,7 @@ int main()
 * ipm arg
 ************************************************/
 
-	int ipm_arg_size = d_tree_ocp_qcqp_ipm_arg_memsize(&dim);
+	hpipm_size_t ipm_arg_size = d_tree_ocp_qcqp_ipm_arg_memsize(&dim);
 #if PRINT
 	printf("\nipm arg size = %d\n", ipm_arg_size);
 #endif
@@ -1080,7 +1080,7 @@ int main()
 * ipm
 ************************************************/
 
-	int ipm_size = d_tree_ocp_qcqp_ipm_ws_memsize(&dim, &arg);
+	hpipm_size_t ipm_size = d_tree_ocp_qcqp_ipm_ws_memsize(&dim, &arg);
 #if PRINT
 	printf("\nipm size = %d\n", ipm_size);
 #endif

--- a/test_problems/test_m_ocp.c
+++ b/test_problems/test_m_ocp.c
@@ -615,7 +615,7 @@ int main()
 * d ocp qp
 ************************************************/	
 	
-	int d_qp_size = d_memsize_ocp_qp(N, nx, nu, nb, ng);
+	hpipm_size_t d_qp_size = d_memsize_ocp_qp(N, nx, nu, nb, ng);
 	printf("\nd qp size = %d\n", d_qp_size);
 	void *d_qp_mem = malloc(d_qp_size);
 
@@ -651,7 +651,7 @@ int main()
 * s ocp qp
 ************************************************/	
 	
-	int s_qp_size = s_memsize_ocp_qp(N, nx, nu, nb, ng);
+	hpipm_size_t s_qp_size = s_memsize_ocp_qp(N, nx, nu, nb, ng);
 	printf("\ns qp size = %d\n", s_qp_size);
 	void *s_qp_mem = malloc(s_qp_size);
 
@@ -689,7 +689,7 @@ int main()
 * ocp qp sol
 ************************************************/	
 	
-	int d_qp_sol_size = d_memsize_ocp_qp_sol(N, nx, nu, nb, ng);
+	hpipm_size_t d_qp_sol_size = d_memsize_ocp_qp_sol(N, nx, nu, nb, ng);
 	printf("\nd qp sol size = %d\n", d_qp_sol_size);
 	void *d_qp_sol_mem = malloc(d_qp_sol_size);
 
@@ -706,7 +706,7 @@ int main()
 	arg.iter_max = 20;
 	arg.mu0 = 2.0;
 
-	int ipm_size = m_memsize_ipm_hard_ocp_qp(&d_qp, &s_qp, &arg);
+	hpipm_size_t ipm_size = m_memsize_ipm_hard_ocp_qp(&d_qp, &s_qp, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *m_ipm_mem = malloc(ipm_size);
 

--- a/test_problems/test_s_dense.c
+++ b/test_problems/test_s_dense.c
@@ -87,7 +87,7 @@ int main()
 * dense qp
 ************************************************/	
 
-	int qp_size = s_memsize_dense_qp(nv, ne, nb, ng);
+	hpipm_size_t qp_size = s_memsize_dense_qp(nv, ne, nb, ng);
 	printf("\nqp size = %d\n", qp_size);
 	void *qp_mem = malloc(qp_size);
 
@@ -110,7 +110,7 @@ int main()
 * dense qp sol
 ************************************************/	
 
-	int qp_sol_size = s_memsize_dense_qp_sol(nv, ne, nb, ng);
+	hpipm_size_t qp_sol_size = s_memsize_dense_qp_sol(nv, ne, nb, ng);
 	printf("\nqp sol size = %d\n", qp_sol_size);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
@@ -127,7 +127,7 @@ int main()
 	arg.iter_max = 20;
 	arg.mu0 = 1.0;
 
-	int ipm_size = s_memsize_ipm_hard_dense_qp(&qp, &arg);
+	hpipm_size_t ipm_size = s_memsize_ipm_hard_dense_qp(&qp, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *ipm_mem = malloc(ipm_size);
 

--- a/test_problems/test_s_ocp.c
+++ b/test_problems/test_s_ocp.c
@@ -509,7 +509,7 @@ int main()
 * ocp qp
 ************************************************/	
 	
-	int qp_size = s_memsize_ocp_qp(N, nx, nu, nb, ng);
+	hpipm_size_t qp_size = s_memsize_ocp_qp(N, nx, nu, nb, ng);
 	printf("\nqp size = %d\n", qp_size);
 	void *qp_mem = malloc(qp_size);
 
@@ -545,7 +545,7 @@ int main()
 * ocp qp
 ************************************************/	
 	
-	int qp_sol_size = s_memsize_ocp_qp_sol(N, nx, nu, nb, ng);
+	hpipm_size_t qp_sol_size = s_memsize_ocp_qp_sol(N, nx, nu, nb, ng);
 	printf("\nqp sol size = %d\n", qp_sol_size);
 	void *qp_sol_mem = malloc(qp_sol_size);
 
@@ -562,7 +562,7 @@ int main()
 	arg.iter_max = 20;
 	arg.mu0 = 2.0;
 
-	int ipm_size = s_memsize_ipm_hard_ocp_qp(&qp, &arg);
+	hpipm_size_t ipm_size = s_memsize_ipm_hard_ocp_qp(&qp, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *ipm_mem = malloc(ipm_size);
 

--- a/test_problems/test_s_tree_ocp.c
+++ b/test_problems/test_s_tree_ocp.c
@@ -494,7 +494,7 @@ int main()
 * create scenario tree
 ************************************************/	
 
-	int tree_memsize = memsize_sctree(md, Nr, Nh);
+	hpipm_size_t tree_memsize = memsize_sctree(md, Nr, Nh);
 	printf("\ntree memsize = %d\n", tree_memsize);
 	void *tree_memory = malloc(tree_memsize);
 
@@ -687,7 +687,7 @@ int main()
 * create tree ocp qp
 ************************************************/	
 
-	int tree_ocp_qp_memsize = s_memsize_tree_ocp_qp(&ttree, nxt, nut, nbt, ngt);
+	hpipm_size_t tree_ocp_qp_memsize = s_memsize_tree_ocp_qp(&ttree, nxt, nut, nbt, ngt);
 	printf("\ntree ocp qp memsize = %d\n", tree_ocp_qp_memsize);
 	void *tree_ocp_qp_memory = malloc(tree_ocp_qp_memsize);
 
@@ -748,7 +748,7 @@ int main()
 * ocp qp sol
 ************************************************/	
 	
-	int tree_ocp_qp_sol_size = s_memsize_tree_ocp_qp_sol(&ttree, nxt, nut, nbt, ngt);
+	hpipm_size_t tree_ocp_qp_sol_size = s_memsize_tree_ocp_qp_sol(&ttree, nxt, nut, nbt, ngt);
 	printf("\ntree ocp qp sol memsize = %d\n", tree_ocp_qp_sol_size);
 	void *tree_ocp_qp_sol_memory = malloc(tree_ocp_qp_sol_size);
 
@@ -765,7 +765,7 @@ int main()
 	arg.iter_max = 20;
 	arg.mu0 = 2.0;
 
-	int ipm_size = s_memsize_ipm_hard_tree_ocp_qp(&qp, &arg);
+	hpipm_size_t ipm_size = s_memsize_ipm_hard_tree_ocp_qp(&qp, &arg);
 	printf("\nipm size = %d\n", ipm_size);
 	void *ipm_memory = malloc(ipm_size);
 

--- a/tree_ocp_qp/scenario_tree.c
+++ b/tree_ocp_qp/scenario_tree.c
@@ -67,12 +67,12 @@ static int sctree_node_number(int md, int Nr, int Nh)
 
 
 
-int sctree_memsize(int md, int Nr, int Nh)
+hpipm_size_t sctree_memsize(int md, int Nr, int Nh)
 	{
 
 	int Nn = sctree_node_number(md, Nr, Nh);
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += Nn*sizeof(struct node); // root
 	size += Nn*sizeof(int); // kids

--- a/tree_ocp_qp/x_tree_ocp_qcqp.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp.c
@@ -35,14 +35,14 @@
 
 
 
-int TREE_OCP_QCQP_STRSIZE()
+hpipm_size_t TREE_OCP_QCQP_STRSIZE()
 	{
 	return sizeof(struct TREE_OCP_QCQP);
 	}
 
 
 
-int TREE_OCP_QCQP_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
+hpipm_size_t TREE_OCP_QCQP_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 	{
 
 	// extract dim
@@ -74,7 +74,7 @@ int TREE_OCP_QCQP_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += Nn*sizeof(struct STRMAT *); // Hq
 
@@ -118,7 +118,7 @@ void TREE_OCP_QCQP_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQP *q
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QCQP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/tree_ocp_qp/x_tree_ocp_qcqp_dim.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_dim.c
@@ -35,10 +35,10 @@
 
 
 
-int TREE_OCP_QCQP_DIM_STRSIZE()
+hpipm_size_t TREE_OCP_QCQP_DIM_STRSIZE()
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += sizeof(struct TREE_OCP_QCQP_DIM);
 
@@ -48,10 +48,10 @@ int TREE_OCP_QCQP_DIM_STRSIZE()
 
 
 
-int TREE_OCP_QCQP_DIM_MEMSIZE(int Nn)
+hpipm_size_t TREE_OCP_QCQP_DIM_MEMSIZE(int Nn)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 12*Nn*sizeof(int);
 
@@ -74,7 +74,7 @@ void TREE_OCP_QCQP_DIM_CREATE(int Nn, struct TREE_OCP_QCQP_DIM *dim, void *memor
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_DIM_MEMSIZE(Nn);
+	hpipm_size_t memsize = TREE_OCP_QCQP_DIM_MEMSIZE(Nn);
 	hpipm_zero_memset(memsize, memory);
 
 	// qp_dim struct

--- a/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
@@ -35,17 +35,17 @@
 
 
 
-int TREE_OCP_QCQP_IPM_ARG_STRSIZE()
+hpipm_size_t TREE_OCP_QCQP_IPM_ARG_STRSIZE()
 	{
 	return sizeof(struct TREE_OCP_QCQP_IPM_ARG);
 	}
 
 
 
-int TREE_OCP_QCQP_IPM_ARG_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
+hpipm_size_t TREE_OCP_QCQP_IPM_ARG_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct TREE_OCP_QP_IPM_ARG);
 	size += 1*TREE_OCP_QP_IPM_ARG_MEMSIZE(dim->qp_dim);
@@ -67,7 +67,7 @@ void TREE_OCP_QCQP_IPM_ARG_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_IPM_ARG_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QCQP_IPM_ARG_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// qp_dim struct
@@ -505,14 +505,14 @@ void TREE_OCP_QCQP_IPM_ARG_SET_T_LAM_MIN(int *value, struct TREE_OCP_QCQP_IPM_AR
 
 
 
-int TREE_OCP_QCQP_IPM_WS_STRSIZE()
+hpipm_size_t TREE_OCP_QCQP_IPM_WS_STRSIZE()
 	{
 	return sizeof(struct TREE_OCP_QCQP_IPM_WS);
 	}
 
 
 
-int TREE_OCP_QCQP_IPM_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQP_IPM_ARG *arg)
+hpipm_size_t TREE_OCP_QCQP_IPM_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQP_IPM_ARG *arg)
 	{
 
 	int Nn = dim->Nn;
@@ -529,7 +529,7 @@ int TREE_OCP_QCQP_IPM_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 		nxM = nx[ii]>nxM ? nx[ii] : nxM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct TREE_OCP_QP_IPM_WS);
 	size += 1*TREE_OCP_QP_IPM_WS_MEMSIZE(dim->qp_dim, arg->qp_arg);
@@ -565,7 +565,7 @@ void TREE_OCP_QCQP_IPM_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = TREE_OCP_QCQP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	int Nn = dim->Nn;

--- a/tree_ocp_qp/x_tree_ocp_qcqp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int TREE_OCP_QCQP_RES_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
+hpipm_size_t TREE_OCP_QCQP_RES_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -65,7 +65,7 @@ int TREE_OCP_QCQP_RES_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*Nn*sizeof(struct STRVEC); // res_g res_d res_m
 	size += 3*(Nn-1)*sizeof(struct STRVEC); // res_b
@@ -90,7 +90,7 @@ void TREE_OCP_QCQP_RES_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 	int ii, idx;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QCQP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -221,7 +221,7 @@ void TREE_OCP_QCQP_RES_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 
 
 
-int TREE_OCP_QCQP_RES_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
+hpipm_size_t TREE_OCP_QCQP_RES_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 	{
 
 	// loop index
@@ -253,7 +253,7 @@ int TREE_OCP_QCQP_RES_WS_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 		nsM = ns[ii]>nsM ? ns[ii] : nsM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += (5+2*Nn)*sizeof(struct STRVEC); // 2*tmp_nuxM 2*tmp_nbgqM tmp_nsM q_fun q_adj
 
@@ -282,7 +282,7 @@ void TREE_OCP_QCQP_RES_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 	int ii, idx;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QCQP_RES_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
@@ -35,7 +35,7 @@
 
 
 
-int TREE_OCP_QCQP_SOL_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
+hpipm_size_t TREE_OCP_QCQP_SOL_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 	{
 
 	// extract dim
@@ -64,7 +64,7 @@ int TREE_OCP_QCQP_SOL_MEMSIZE(struct TREE_OCP_QCQP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*Nn*sizeof(struct STRVEC); // ux lam t
 	size += 1*(Nn-1)*sizeof(struct STRVEC); // pi
@@ -86,7 +86,7 @@ void TREE_OCP_QCQP_SOL_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QCQP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QCQP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/tree_ocp_qp/x_tree_ocp_qp.c
+++ b/tree_ocp_qp/x_tree_ocp_qp.c
@@ -35,14 +35,14 @@
 
 
 
-int TREE_OCP_QP_STRSIZE()
+hpipm_size_t TREE_OCP_QP_STRSIZE()
 	{
 	return sizeof(struct TREE_OCP_QP);
 	}
 
 
 
-int TREE_OCP_QP_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
+hpipm_size_t TREE_OCP_QP_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 	{
 
 	// extract dim
@@ -71,7 +71,7 @@ int TREE_OCP_QP_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 2*Nn*sizeof(int *); // idxb idxs_rev
 //	size += 1*Nn*sizeof(int *); // idxs
@@ -114,7 +114,7 @@ void TREE_OCP_QP_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP *qp, voi
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QP_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim

--- a/tree_ocp_qp/x_tree_ocp_qp_dim.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_dim.c
@@ -35,17 +35,17 @@
 
 
 
-int TREE_OCP_QP_DIM_STRSIZE()
+hpipm_size_t TREE_OCP_QP_DIM_STRSIZE()
 	{
 	return sizeof(struct TREE_OCP_QP_DIM);
 	}
 
 
 
-int TREE_OCP_QP_DIM_MEMSIZE(int Nn)
+hpipm_size_t TREE_OCP_QP_DIM_MEMSIZE(int Nn)
 	{
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 10*Nn*sizeof(int);
 
@@ -64,7 +64,7 @@ void TREE_OCP_QP_DIM_CREATE(int Nn, struct TREE_OCP_QP_DIM *dim, void *memory)
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_DIM_MEMSIZE(Nn);
+	hpipm_size_t memsize = TREE_OCP_QP_DIM_MEMSIZE(Nn);
 	hpipm_zero_memset(memsize, memory);
 
 	char *c_ptr = memory;

--- a/tree_ocp_qp/x_tree_ocp_qp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_ipm.c
@@ -37,7 +37,7 @@
 
 
 
-int TREE_OCP_QP_IPM_ARG_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
+hpipm_size_t TREE_OCP_QP_IPM_ARG_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 	{
 
 	return 0;
@@ -366,7 +366,7 @@ void TREE_OCP_QP_IPM_ARG_SET_T_LAM_MIN(int *value, struct TREE_OCP_QP_IPM_ARG *a
 
 
 
-int TREE_OCP_QP_IPM_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_IPM_ARG *arg)
+hpipm_size_t TREE_OCP_QP_IPM_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_IPM_ARG *arg)
 	{
 
 	// stat_max is at least as big as iter_max
@@ -412,7 +412,7 @@ int TREE_OCP_QP_IPM_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_I
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 	nsM = ns[ii]>nsM ? ns[ii] : nsM;
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 1*sizeof(struct CORE_QP_IPM_WORKSPACE);
 	size += 1*MEMSIZE_CORE_QP_IPM(nvt, net, nct);
@@ -475,7 +475,7 @@ void TREE_OCP_QP_IPM_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_I
 	int ii;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_IPM_WS_MEMSIZE(dim, arg);
+	hpipm_size_t memsize = TREE_OCP_QP_IPM_WS_MEMSIZE(dim, arg);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/tree_ocp_qp/x_tree_ocp_qp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_res.c
@@ -35,7 +35,7 @@
 
 
 
-int TREE_OCP_QP_RES_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
+hpipm_size_t TREE_OCP_QP_RES_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 	{
 
 	// loop index
@@ -64,7 +64,7 @@ int TREE_OCP_QP_RES_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*Nn*sizeof(struct STRVEC); // res_g res_d res_m
 	size += 3*(Nn-1)*sizeof(struct STRVEC); // res_b
@@ -89,7 +89,7 @@ void TREE_OCP_QP_RES_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_RES 
 	int ii, idx;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_RES_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QP_RES_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size
@@ -215,7 +215,7 @@ void TREE_OCP_QP_RES_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_RES 
 
 
 
-int TREE_OCP_QP_RES_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
+hpipm_size_t TREE_OCP_QP_RES_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 	{
 
 	// loop index
@@ -240,7 +240,7 @@ int TREE_OCP_QP_RES_WS_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 		nsM = ns[ii]>nsM ? ns[ii] : nsM;
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*sizeof(struct STRVEC); // 2*tmp_nbgM tmp_nsM
 
@@ -263,7 +263,7 @@ void TREE_OCP_QP_RES_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_R
 	int ii, idx;
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_RES_WS_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QP_RES_WS_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract ocp qp size

--- a/tree_ocp_qp/x_tree_ocp_qp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_sol.c
@@ -33,7 +33,7 @@
 *                                                                                                 *
 **************************************************************************************************/
 
-int TREE_OCP_QP_SOL_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
+hpipm_size_t TREE_OCP_QP_SOL_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 	{
 
 	// extract dim
@@ -61,7 +61,7 @@ int TREE_OCP_QP_SOL_MEMSIZE(struct TREE_OCP_QP_DIM *dim)
 		net += nx[idx];
 		}
 
-	int size = 0;
+	hpipm_size_t size = 0;
 
 	size += 3*Nn*sizeof(struct STRVEC); // ux lam t
 	size += 1*(Nn-1)*sizeof(struct STRVEC); // pi
@@ -83,7 +83,7 @@ void TREE_OCP_QP_SOL_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_SOL 
 	{
 
 	// zero memory (to avoid corrupted memory like e.g. NaN)
-	int memsize = TREE_OCP_QP_SOL_MEMSIZE(dim);
+	hpipm_size_t memsize = TREE_OCP_QP_SOL_MEMSIZE(dim);
 	hpipm_zero_memset(memsize, mem);
 
 	// extract dim


### PR DESCRIPTION
For larger problems with high memory demand (>2GB) using type int is a
limiting factor. A configurable typedef "hpipm_size_t" defined in
include/hpipm_common.h can be set depending on the problem size to expect
and depending on the platform/OS.