### PR TITLE
use size_t to align to typical cache line size

### DIFF
--- a/benchmark/test_d_benchmark.c
+++ b/benchmark/test_d_benchmark.c
@@ -137,7 +137,7 @@ void d_create_benchmark_to_hpipm(int nv, int ne, int nc, struct benchmark_to_hpi
 	i_ptr += nv;
 
 	// align data
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+7)/8*8;
 
 	// char pointer

--- a/cond/d_elim_x0.c
+++ b/cond/d_elim_x0.c
@@ -108,7 +108,7 @@ void CREATE_ELIM_X0(struct OCP_QP *qp, struct ELIM_X0_WORKSPACE *ws, void *mem)
 	sv_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void stuff

--- a/cond/d_elim_x0.c
+++ b/cond/d_elim_x0.c
@@ -107,7 +107,7 @@ void CREATE_ELIM_X0(struct OCP_QP *qp, struct ELIM_X0_WORKSPACE *ws, void *mem)
 	ws->x0 = sv_ptr;
 	sv_ptr += 1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/cond/x_cond.c
+++ b/cond/x_cond.c
@@ -339,7 +339,7 @@ void COND_QP_WS_CREATE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg,
 	ngM = ng[ii]>ngM ? ng[ii] : ngM;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	s_ptr = (size_t) mem;
 	s_ptr = (s_ptr+7)/8*8;
 
@@ -381,7 +381,7 @@ void COND_QP_WS_CREATE(struct OCP_QP_DIM *ocp_dim, struct COND_QP_ARG *cond_arg,
 		}
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/cond/x_cond_qcqp.c
+++ b/cond/x_cond_qcqp.c
@@ -374,7 +374,7 @@ void COND_QCQP_WS_CREATE(struct OCP_QCQP_DIM *ocp_dim, struct COND_QCQP_ARG *con
 	cond_ws->tmp_nuxM = sv_ptr;
 	sv_ptr += 1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/cond/x_cond_qcqp.c
+++ b/cond/x_cond_qcqp.c
@@ -133,7 +133,7 @@ void COND_QCQP_ARG_CREATE(struct COND_QCQP_ARG *cond_arg, void *mem)
 	arg_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) arg_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) arg_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void
@@ -375,7 +375,7 @@ void COND_QCQP_WS_CREATE(struct OCP_QCQP_DIM *ocp_dim, struct COND_QCQP_ARG *con
 	sv_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void stuf

--- a/cond/x_part_cond.c
+++ b/cond/x_part_cond.c
@@ -186,7 +186,7 @@ void PART_COND_QP_ARG_CREATE(int N2, struct PART_COND_QP_ARG *part_cond_arg, voi
 	part_cond_arg->cond_arg = cws_ptr;
 	cws_ptr += N2+1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -374,7 +374,7 @@ void PART_COND_QP_WS_CREATE(struct OCP_QP_DIM *ocp_dim, int *block_size, struct 
 	part_cond_ws->cond_workspace = cws_ptr;
 	cws_ptr += N2+1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/cond/x_part_cond.c
+++ b/cond/x_part_cond.c
@@ -187,7 +187,7 @@ void PART_COND_QP_ARG_CREATE(int N2, struct PART_COND_QP_ARG *part_cond_arg, voi
 	cws_ptr += N2+1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) cws_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	char *c_ptr = (char *) s_ptr;
@@ -375,7 +375,7 @@ void PART_COND_QP_WS_CREATE(struct OCP_QP_DIM *ocp_dim, int *block_size, struct 
 	cws_ptr += N2+1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) cws_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	char *c_ptr = (char *) s_ptr;

--- a/cond/x_part_cond_qcqp.c
+++ b/cond/x_part_cond_qcqp.c
@@ -225,7 +225,7 @@ void PART_COND_QCQP_ARG_CREATE(int N2, struct PART_COND_QCQP_ARG *part_cond_arg,
 	cws_ptr += N2+1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) cws_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	char *c_ptr = (char *) s_ptr;
@@ -378,7 +378,7 @@ void PART_COND_QCQP_WS_CREATE(struct OCP_QCQP_DIM *ocp_dim, int *block_size, str
 	cws_ptr += N2+1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) cws_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	char *c_ptr = (char *) s_ptr;

--- a/cond/x_part_cond_qcqp.c
+++ b/cond/x_part_cond_qcqp.c
@@ -224,7 +224,7 @@ void PART_COND_QCQP_ARG_CREATE(int N2, struct PART_COND_QCQP_ARG *part_cond_arg,
 	part_cond_arg->cond_arg = cws_ptr;
 	cws_ptr += N2+1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -377,7 +377,7 @@ void PART_COND_QCQP_WS_CREATE(struct OCP_QCQP_DIM *ocp_dim, int *block_size, str
 	part_cond_ws->cond_ws = cws_ptr;
 	cws_ptr += N2+1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) cws_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/dense_qp/x_dense_qcqp.c
+++ b/dense_qp/x_dense_qcqp.c
@@ -148,7 +148,7 @@ void DENSE_QCQP_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP *qp, void *
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qcqp_dim.c
+++ b/dense_qp/x_dense_qcqp_dim.c
@@ -66,7 +66,7 @@ void DENSE_QCQP_DIM_CREATE(struct DENSE_QCQP_DIM *dim, void *mem)
 	dim_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) dim_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) dim_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void

--- a/dense_qp/x_dense_qcqp_ipm.c
+++ b/dense_qp/x_dense_qcqp_ipm.c
@@ -570,7 +570,7 @@ void DENSE_QCQP_IPM_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM_
 	sv_ptr += 2;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/dense_qp/x_dense_qcqp_ipm.c
+++ b/dense_qp/x_dense_qcqp_ipm.c
@@ -69,7 +69,7 @@ void DENSE_QCQP_IPM_ARG_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM
 	arg_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) arg_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) arg_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void
@@ -571,7 +571,7 @@ void DENSE_QCQP_IPM_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_IPM_
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qcqp_res.c
+++ b/dense_qp/x_dense_qcqp_res.c
@@ -98,7 +98,7 @@ void DENSE_QCQP_RES_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES *re
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -204,7 +204,7 @@ void DENSE_QCQP_RES_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES_
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/dense_qp/x_dense_qcqp_res.c
+++ b/dense_qp/x_dense_qcqp_res.c
@@ -99,7 +99,7 @@ void DENSE_QCQP_RES_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES *re
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -205,7 +205,7 @@ void DENSE_QCQP_RES_WS_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES_
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qcqp_res.c
+++ b/dense_qp/x_dense_qcqp_res.c
@@ -126,7 +126,7 @@ void DENSE_QCQP_RES_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_RES *re
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + res->memsize)
 		{
-		printf("\ncreate_dense_qp_res: outsize memory bounds!\n\n");
+		printf("\ncreate_dense_qcpp_res: outsize memory bounds!\n\n");
 		exit(1);
 		}
 #endif

--- a/dense_qp/x_dense_qcqp_sol.c
+++ b/dense_qp/x_dense_qcqp_sol.c
@@ -95,7 +95,7 @@ void DENSE_QCQP_SOL_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_SOL *qp
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qcqp_sol.c
+++ b/dense_qp/x_dense_qcqp_sol.c
@@ -95,7 +95,7 @@ void DENSE_QCQP_SOL_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_SOL *qp
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 
@@ -127,7 +127,7 @@ void DENSE_QCQP_SOL_CREATE(struct DENSE_QCQP_DIM *dim, struct DENSE_QCQP_SOL *qp
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + qp_sol->memsize)
 		{
-		printf("\nCreate_ocp_qp_sol: outsize memory bounds!\n\n");
+		printf("\nCreate_dense_qp_sol: outsize memory bounds!\n\n");
 		exit(1);
 		}
 #endif

--- a/dense_qp/x_dense_qp.c
+++ b/dense_qp/x_dense_qp.c
@@ -137,7 +137,7 @@ void DENSE_QP_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP *qp, void *mem)
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qp_ipm.c
+++ b/dense_qp/x_dense_qp_ipm.c
@@ -828,7 +828,7 @@ void DENSE_QP_IPM_WS_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *a
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qp_res.c
+++ b/dense_qp/x_dense_qp_res.c
@@ -96,7 +96,7 @@ void DENSE_QP_RES_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES *res, voi
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -216,7 +216,7 @@ void DENSE_QP_RES_WS_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES_WS *ws
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/dense_qp/x_dense_qp_res.c
+++ b/dense_qp/x_dense_qp_res.c
@@ -97,7 +97,7 @@ void DENSE_QP_RES_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES *res, voi
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -217,7 +217,7 @@ void DENSE_QP_RES_WS_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_RES_WS *ws
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/dense_qp/x_dense_qp_sol.c
+++ b/dense_qp/x_dense_qp_sol.c
@@ -54,7 +54,7 @@ hpipm_size_t DENSE_QP_SOL_MEMSIZE(struct DENSE_QP_DIM *dim)
 
 	size = (size+63)/64*64; // make multiple of typical cache line size
 	size += 64; // align to typical cache line size
-	
+
 	return size;
 
 	}
@@ -93,7 +93,7 @@ void DENSE_QP_SOL_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_SOL *qp_sol, 
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 
@@ -126,7 +126,7 @@ void DENSE_QP_SOL_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_SOL *qp_sol, 
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + qp_sol->memsize)
 		{
-		printf("\nCreate_ocp_qp_sol: outsize memory bounds!\n\n");
+		printf("\nDENSE_QP_SOL_CREATE: outsize memory bounds!\n\n");
 		exit(1);
 		}
 #endif

--- a/dense_qp/x_dense_qp_sol.c
+++ b/dense_qp/x_dense_qp_sol.c
@@ -93,7 +93,7 @@ void DENSE_QP_SOL_CREATE(struct DENSE_QP_DIM *dim, struct DENSE_QP_SOL *qp_sol, 
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/m_ocp_qp_ipm_hard.c
+++ b/ocp_qp/m_ocp_qp_ipm_hard.c
@@ -260,7 +260,7 @@ void m_create_ipm_hard_ocp_qp(struct d_ocp_qp *qp, struct s_ocp_qp *s_qp, struct
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/ocp_qp/m_ocp_qp_ipm_hard.c
+++ b/ocp_qp/m_ocp_qp_ipm_hard.c
@@ -259,7 +259,7 @@ void m_create_ipm_hard_ocp_qp(struct d_ocp_qp *qp, struct s_ocp_qp *s_qp, struct
 	sv_ptr += 2;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/ocp_qp/x_ocp_qcqp.c
+++ b/ocp_qp/x_ocp_qcqp.c
@@ -248,7 +248,7 @@ void OCP_QCQP_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP *qp, void *mem)
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) i_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp.c
+++ b/ocp_qp/x_ocp_qcqp.c
@@ -248,7 +248,7 @@ void OCP_QCQP_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP *qp, void *mem)
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) i_ptr;
+	size_t l_ptr = (size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp_dim.c
+++ b/ocp_qp/x_ocp_qcqp_dim.c
@@ -84,7 +84,7 @@ void OCP_QCQP_DIM_CREATE(int N, struct OCP_QCQP_DIM *dim, void *mem)
 	dim_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) dim_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) dim_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void

--- a/ocp_qp/x_ocp_qcqp_ipm.c
+++ b/ocp_qp/x_ocp_qcqp_ipm.c
@@ -608,7 +608,7 @@ void OCP_QCQP_IPM_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *a
 	sv_ptr += 2;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/ocp_qp/x_ocp_qcqp_ipm.c
+++ b/ocp_qp/x_ocp_qcqp_ipm.c
@@ -77,7 +77,7 @@ void OCP_QCQP_IPM_ARG_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *
 	arg_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) arg_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) arg_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void
@@ -609,7 +609,7 @@ void OCP_QCQP_IPM_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_IPM_ARG *a
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp_res.c
+++ b/ocp_qp/x_ocp_qcqp_res.c
@@ -204,7 +204,7 @@ void OCP_QCQP_RES_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES *res, voi
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + res->memsize)
 		{
-		printf("\ncreate_ocp_qp_res: outside memory bounds!\n\n");
+		printf("\ncreate_ocp_qcqp_res: outside memory bounds!\n\n");
 		exit(1);
 		}
 #endif
@@ -366,7 +366,7 @@ void OCP_QCQP_RES_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES_WS *ws
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + ws->memsize)
 		{
-		printf("\ncreate_ocp_qp_res_workspace: outside memory bounds!\n\n");
+		printf("\ncreate_ocp_qcqp_res_workspace: outside memory bounds!\n\n");
 		exit(1);
 		}
 #endif

--- a/ocp_qp/x_ocp_qcqp_res.c
+++ b/ocp_qp/x_ocp_qcqp_res.c
@@ -128,7 +128,7 @@ void OCP_QCQP_RES_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES *res, voi
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -324,7 +324,7 @@ void OCP_QCQP_RES_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES_WS *ws
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp_res.c
+++ b/ocp_qp/x_ocp_qcqp_res.c
@@ -127,7 +127,7 @@ void OCP_QCQP_RES_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES *res, voi
 	sv_ptr += N+1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -323,7 +323,7 @@ void OCP_QCQP_RES_WS_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_RES_WS *ws
 	sv_ptr += N+1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/ocp_qp/x_ocp_qcqp_sol.c
+++ b/ocp_qp/x_ocp_qcqp_sol.c
@@ -133,7 +133,7 @@ void OCP_QCQP_SOL_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_SOL *qp_sol, 
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp_sol.c
+++ b/ocp_qp/x_ocp_qcqp_sol.c
@@ -133,7 +133,7 @@ void OCP_QCQP_SOL_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_SOL *qp_sol, 
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qcqp_sol.c
+++ b/ocp_qp/x_ocp_qcqp_sol.c
@@ -205,7 +205,7 @@ void OCP_QCQP_SOL_CREATE(struct OCP_QCQP_DIM *dim, struct OCP_QCQP_SOL *qp_sol, 
 #if defined(RUNTIME_CHECKS)
 	if(c_ptr > ((char *) mem) + qp_sol->memsize)
 		{
-		printf("\nCreate_ocp_qp_sol: outsize memory bounds!\n\n");
+		printf("\nCreate_ocp_qcqp_sol: outsize memory bounds!\n\n");
 		exit(1);
 		}
 #endif

--- a/ocp_qp/x_ocp_qp.c
+++ b/ocp_qp/x_ocp_qp.c
@@ -247,7 +247,7 @@ void OCP_QP_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP *qp, void *mem)
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) i_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qp.c
+++ b/ocp_qp/x_ocp_qp.c
@@ -247,7 +247,7 @@ void OCP_QP_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP *qp, void *mem)
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) i_ptr;
+	size_t l_ptr = (size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qp_ipm.c
+++ b/ocp_qp/x_ocp_qp_ipm.c
@@ -802,7 +802,7 @@ void OCP_QP_IPM_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg, st
 	i_ptr += N+1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qp_ipm.c
+++ b/ocp_qp/x_ocp_qp_ipm.c
@@ -801,7 +801,7 @@ void OCP_QP_IPM_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_IPM_ARG *arg, st
 	workspace->use_hess_fact = i_ptr;
 	i_ptr += N+1;
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/ocp_qp/x_ocp_qp_red.c
+++ b/ocp_qp/x_ocp_qp_red.c
@@ -241,7 +241,7 @@ void OCP_QP_REDUCE_EQ_DOF_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_REDUCE
 	i_ptr += nbgM;
 
 	// align to typical cache line size
-	long long l_ptr = (long long) i_ptr;
+	size_t l_ptr = (size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 	// floating point stuff

--- a/ocp_qp/x_ocp_qp_red.c
+++ b/ocp_qp/x_ocp_qp_red.c
@@ -241,7 +241,7 @@ void OCP_QP_REDUCE_EQ_DOF_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_REDUCE
 	i_ptr += nbgM;
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) i_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 	// floating point stuff

--- a/ocp_qp/x_ocp_qp_res.c
+++ b/ocp_qp/x_ocp_qp_res.c
@@ -126,7 +126,7 @@ void OCP_QP_RES_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES *res, void *mem
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -298,7 +298,7 @@ void OCP_QP_RES_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES_WS *ws, void
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qp_res.c
+++ b/ocp_qp/x_ocp_qp_res.c
@@ -125,7 +125,7 @@ void OCP_QP_RES_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES *res, void *mem
 	sv_ptr += N+1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -297,7 +297,7 @@ void OCP_QP_RES_WS_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_RES_WS *ws, void
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/ocp_qp/x_ocp_qp_sol.c
+++ b/ocp_qp/x_ocp_qp_sol.c
@@ -131,7 +131,7 @@ void OCP_QP_SOL_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_SOL *qp_sol, void *
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/ocp_qp/x_ocp_qp_sol.c
+++ b/ocp_qp/x_ocp_qp_sol.c
@@ -131,7 +131,7 @@ void OCP_QP_SOL_CREATE(struct OCP_QP_DIM *dim, struct OCP_QP_SOL *qp_sol, void *
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp.c
@@ -247,7 +247,7 @@ void TREE_OCP_QCQP_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQP *q
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) i_ptr;
+	size_t l_ptr = (size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp.c
@@ -247,7 +247,7 @@ void TREE_OCP_QCQP_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQP *q
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) i_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_dim.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_dim.c
@@ -84,7 +84,7 @@ void TREE_OCP_QCQP_DIM_CREATE(int Nn, struct TREE_OCP_QCQP_DIM *dim, void *memor
 	dim_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) dim_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) dim_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void

--- a/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
@@ -608,7 +608,7 @@ void TREE_OCP_QCQP_IPM_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 	sv_ptr += 2;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_ipm.c
@@ -77,7 +77,7 @@ void TREE_OCP_QCQP_IPM_ARG_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP
 	arg_ptr += 1;
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) arg_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) arg_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 	// void
@@ -609,7 +609,7 @@ void TREE_OCP_QCQP_IPM_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_res.c
@@ -132,7 +132,7 @@ void TREE_OCP_QCQP_RES_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -329,7 +329,7 @@ void TREE_OCP_QCQP_RES_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_res.c
@@ -131,7 +131,7 @@ void TREE_OCP_QCQP_RES_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 	sv_ptr += Nn;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -328,7 +328,7 @@ void TREE_OCP_QCQP_RES_WS_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_
 	sv_ptr += Nn;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
@@ -131,7 +131,7 @@ void TREE_OCP_QCQP_SOL_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qcqp_sol.c
@@ -131,7 +131,7 @@ void TREE_OCP_QCQP_SOL_CREATE(struct TREE_OCP_QCQP_DIM *dim, struct TREE_OCP_QCQ
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp.c
+++ b/tree_ocp_qp/x_tree_ocp_qp.c
@@ -238,7 +238,7 @@ void TREE_OCP_QP_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP *qp, voi
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) i_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp.c
+++ b/tree_ocp_qp/x_tree_ocp_qp.c
@@ -238,7 +238,7 @@ void TREE_OCP_QP_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP *qp, voi
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) i_ptr;
+	size_t l_ptr = (size_t) i_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_ipm.c
@@ -631,7 +631,7 @@ void TREE_OCP_QP_IPM_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_I
 	i_ptr += Nn;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/tree_ocp_qp/x_tree_ocp_qp_ipm.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_ipm.c
@@ -632,7 +632,7 @@ void TREE_OCP_QP_IPM_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_I
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) i_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) i_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_res.c
@@ -129,7 +129,7 @@ void TREE_OCP_QP_RES_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_RES 
 	sv_ptr += Nn;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
@@ -296,7 +296,7 @@ void TREE_OCP_QP_RES_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_R
 	sv_ptr += 1;
 
 
-	// align to typicl cache line size
+	// align to typical cache line size
 	size_t s_ptr = (size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 

--- a/tree_ocp_qp/x_tree_ocp_qp_res.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_res.c
@@ -130,7 +130,7 @@ void TREE_OCP_QP_RES_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_RES 
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 
@@ -297,7 +297,7 @@ void TREE_OCP_QP_RES_WS_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_R
 
 
 	// align to typical cache line size
-	size_t s_ptr = (size_t) sv_ptr;
+	hpipm_size_t s_ptr = (hpipm_size_t) sv_ptr;
 	s_ptr = (s_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_sol.c
@@ -125,7 +125,7 @@ void TREE_OCP_QP_SOL_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_SOL 
 
 
 	// align to typical cache line size
-	size_t l_ptr = (size_t) sv_ptr;
+	hpipm_size_t l_ptr = (hpipm_size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 

--- a/tree_ocp_qp/x_tree_ocp_qp_sol.c
+++ b/tree_ocp_qp/x_tree_ocp_qp_sol.c
@@ -125,7 +125,7 @@ void TREE_OCP_QP_SOL_CREATE(struct TREE_OCP_QP_DIM *dim, struct TREE_OCP_QP_SOL 
 
 
 	// align to typical cache line size
-	long long l_ptr = (long long) sv_ptr;
+	size_t l_ptr = (size_t) sv_ptr;
 	l_ptr = (l_ptr+63)/64*64;
 
 


### PR DESCRIPTION
I was running the acados C tests on a Raspberry Pi 2 and ran into the "outsize memory bounds" message.
After some debugging it turned out that the pointer was casted into a negative number somehow and the alignment didn't work correctly there.