### PR TITLE
Bugfix for qp_sol.get and qcqp_sol

### DIFF
--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_sol.py
@@ -34,7 +34,7 @@
 ###################################################################################################
 
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
@@ -92,7 +92,7 @@ class hpipm_ocp_qcqp_sol:
 				tmp_ptr = cast(nu.ctypes.data, POINTER(c_int))
 				self.__hpipm.d_ocp_qcqp_dim_get_nu(self.dim.dim_struct, i, tmp_ptr)
 				u.append(np.zeros((nu[0,0], 1)))
-				tmp_ptr = cast(u[i].ctypes.data, POINTER(c_double))
+				tmp_ptr = cast(u[-1].ctypes.data, POINTER(c_double))
 				self.__hpipm.d_ocp_qcqp_sol_get_u(i, self.qp_sol_struct, tmp_ptr)
 		return u
 
@@ -114,15 +114,11 @@ class hpipm_ocp_qcqp_sol:
 				tmp_ptr = cast(nx.ctypes.data, POINTER(c_int))
 				self.__hpipm.d_ocp_qcqp_dim_get_nx(self.dim.dim_struct, i, tmp_ptr)
 				x.append(np.zeros((nx[0,0], 1)))
-				tmp_ptr = cast(x[i].ctypes.data, POINTER(c_double))
+				tmp_ptr = cast(x[-1].ctypes.data, POINTER(c_double))
 				self.__hpipm.d_ocp_qcqp_sol_get_x(i, self.qp_sol_struct, tmp_ptr)
 		return x
 
 
 	def print_C_struct(self):
 		self.__hpipm.d_ocp_qcqp_sol_print(self.dim.dim_struct, self.qp_sol_struct)
-		return 
-
-
-
-
+		return

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
@@ -34,7 +34,7 @@
 ###################################################################################################
 
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
@@ -85,7 +85,6 @@ class hpipm_ocp_qp_sol:
 		}
 
 	def get(self, field, idx_start, idx_end=None):
-		'''Returns solution field in shape D x N'''
 		if field not in self.__getters:
 			raise NameError('hpipm_ocp_qp_sol.get: wrong field')
 		else:
@@ -104,14 +103,12 @@ class hpipm_ocp_qp_sol:
 			tmp_ptr = cast(n_var.ctypes.data, POINTER(c_int))
 			getter['n_var'](self.dim.dim_struct, i, tmp_ptr)
 
-			var.append(np.zeros(n_var[0,0]))
+			var.append(np.zeros((n_var[0,0], 1)))
 			tmp_ptr = cast(var[-1].ctypes.data, POINTER(c_double))
 			getter['var'](i, self.qp_sol_struct, tmp_ptr)
-		return np.array(var).T
+
+		return var if len(var) > 1 else var[0]
 
 	def print_C_struct(self):
 		self.__hpipm.d_ocp_qp_sol_print(self.dim.dim_struct, self.qp_sol_struct)
-		return 
-
-
-
+		return


### PR DESCRIPTION
This fixes the warning from https://github.com/giaf/hpipm/issues/108#issuecomment-988290314 - a list of Dx1 arrays if multiple time points are queried and a single Dx1 array for a single time point. I also fixed the bug in the qcqp part, but didn't refactor this yet.