### PR TITLE
add data for minimal example nan issue

### DIFF
--- a/examples/c/nan_issue/qp_dims.c
+++ b/examples/c/nan_issue/qp_dims.c
@@ -1,0 +1,38 @@
+/***************
+* dim
+***************/
+/* N */
+int N = 1;
+/* nx */
+static int nnx[] = {1, 1, };
+int *nx = nnx;
+/* nu */
+static int nnu[] = {0, 0, };
+int *nu = nnu;
+/* nbx */
+static int nnbx[] = {0, 0, };
+int *nbx = nnbx;
+/* nbu */
+static int nnbu[] = {0, 0, };
+int *nbu = nnbu;
+/* ng */
+static int nng[] = {0, 0, };
+int *ng = nng;
+/* nsbx */
+static int nnsbx[] = {0, 0, };
+int *nsbx = nnsbx;
+/* nsbu */
+static int nnsbu[] = {0, 0, };
+int *nsbu = nnsbu;
+/* nsg */
+static int nnsg[] = {0, 0, };
+int *nsg = nnsg;
+/* nbxe */
+static int nnbxe[] = {0, 0, };
+int *nbxe = nnbxe;
+/* nbue */
+static int nnbue[] = {0, 0, };
+int *nbue = nnbue;
+/* nge */
+static int nnge[] = {0, 0, };
+int *nge = nnge;

--- a/examples/c/nan_issue/qp_in.c
+++ b/examples/c/nan_issue/qp_in.c
@@ -1,0 +1,165 @@
+/***************
+* qp
+***************/
+/* A */
+static double A0[] = {1.000000000000000e+00, };
+static double *AA[] = {A0, };
+double **hA = AA;
+/* B */
+static double B0[] = {};
+static double *BB[] = {B0, };
+double **hB = BB;
+/* b */
+static double b0[] = {0.000000000000000e+00, };
+static double *bb[] = {b0, };
+double **hb = bb;
+/* Q */
+static double Q0[] = {0.000000000000000e+00, };
+static double Q1[] = {              -nan, };
+static double *QQ[] = {Q0, Q1, };
+double **hQ = QQ;
+/* S */
+static double S0[] = {};
+static double S1[] = {};
+static double *SS[] = {S0, S1, };
+double **hS = SS;
+/* R */
+static double R0[] = {};
+static double R1[] = {};
+static double *RR[] = {R0, R1, };
+double **hR = RR;
+/* r */
+static double r0[] = {};
+static double r1[] = {};
+static double *rr[] = {r0, r1, };
+double **hr = rr;
+/* q */
+static double q0[] = {0.000000000000000e+00, };
+static double q1[] = {              -nan, };
+static double *qq[] = {q0, q1, };
+double **hq = qq;
+/* idxbu */
+static int idxbu0[] = {};
+static int idxbu1[] = {};
+static int *iidxbu[] = {idxbu0, idxbu1, };
+int **hidxbu = iidxbu;
+/* lbu */
+static double lbu0[] = {};
+static double lbu1[] = {};
+static double *llbu[] = {lbu0, lbu1, };
+double **hlbu = llbu;
+/* lbu_mask */
+static double lbu_mask0[] = {};
+static double lbu_mask1[] = {};
+static double *llbu_mask[] = {lbu_mask0, lbu_mask1, };
+double **hlbu_mask = llbu_mask;
+/* ubu */
+static double ubu0[] = {};
+static double ubu1[] = {};
+static double *uubu[] = {ubu0, ubu1, };
+double **hubu = uubu;
+/* ubu_mask */
+static double ubu_mask0[] = {};
+static double ubu_mask1[] = {};
+static double *uubu_mask[] = {ubu_mask0, ubu_mask1, };
+double **hubu_mask = uubu_mask;
+/* idxbx */
+static int idxbx0[] = {};
+static int idxbx1[] = {};
+static int *iidxbx[] = {idxbx0, idxbx1, };
+int **hidxbx = iidxbx;
+/* lbx */
+static double lbx0[] = {};
+static double lbx1[] = {};
+static double *llbx[] = {lbx0, lbx1, };
+double **hlbx = llbx;
+/* lbx_mask */
+static double lbx_mask0[] = {};
+static double lbx_mask1[] = {};
+static double *llbx_mask[] = {lbx_mask0, lbx_mask1, };
+double **hlbx_mask = llbx_mask;
+/* ubx */
+static double ubx0[] = {};
+static double ubx1[] = {};
+static double *uubx[] = {ubx0, ubx1, };
+double **hubx = uubx;
+/* ubx_mask */
+static double ubx_mask0[] = {};
+static double ubx_mask1[] = {};
+static double *uubx_mask[] = {ubx_mask0, ubx_mask1, };
+double **hubx_mask = uubx_mask;
+/* C */
+static double C0[] = {};
+static double C1[] = {};
+static double *CC[] = {C0, C1, };
+double **hC = CC;
+/* D */
+static double D0[] = {};
+static double D1[] = {};
+static double *DD[] = {D0, D1, };
+double **hD = DD;
+/* lg */
+static double lg0[] = {};
+static double lg1[] = {};
+static double *llg[] = {lg0, lg1, };
+double **hlg = llg;
+/* lg_mask */
+static double lg_mask0[] = {};
+static double lg_mask1[] = {};
+static double *llg_mask[] = {lg_mask0, lg_mask1, };
+double **hlg_mask = llg_mask;
+/* ug */
+static double ug0[] = {};
+static double ug1[] = {};
+static double *uug[] = {ug0, ug1, };
+double **hug = uug;
+/* ug_mask */
+static double ug_mask0[] = {};
+static double ug_mask1[] = {};
+static double *uug_mask[] = {ug_mask0, ug_mask1, };
+double **hug_mask = uug_mask;
+/* Zl */
+static double Zl0[] = {};
+static double Zl1[] = {};
+static double *ZZl[] = {Zl0, Zl1, };
+double **hZl = ZZl;
+/* Zu */
+static double Zu0[] = {};
+static double Zu1[] = {};
+static double *ZZu[] = {Zu0, Zu1, };
+double **hZu = ZZu;
+/* zl */
+static double zl0[] = {};
+static double zl1[] = {};
+static double *zzl[] = {zl0, zl1, };
+double **hzl = zzl;
+/* zu */
+static double zu0[] = {};
+static double zu1[] = {};
+static double *zzu[] = {zu0, zu1, };
+double **hzu = zzu;
+/* idxs_rev */
+static int idxs_rev0[] = {};
+static int idxs_rev1[] = {};
+static int *iidxs_rev[] = {idxs_rev0, idxs_rev1, };
+int **hidxs_rev = iidxs_rev;
+/* idxs */
+static int idxs0[] = {};
+static int idxs1[] = {};
+static int *iidxs[] = {idxs0, idxs1, };
+int **hidxs = iidxs;
+/* lls */
+static double lls0[] = {};
+static double lls1[] = {};
+static double *llls[] = {lls0, lls1, };
+double **hlls = llls;
+/* lus */
+static double lus0[] = {};
+static double lus1[] = {};
+static double *llus[] = {lus0, lus1, };
+double **hlus = llus;
+/* idxe */
+static int idxe0[] = {};
+static int idxe1[] = {};
+static int *iidxe[] = {idxe0, idxe1, };
+int **hidxe = iidxe;


### PR DESCRIPTION
I wanted to add a test problem in acados, where SQP without globalization fails.
When linearizing the NLP, there are some NaNs in qp_in.
HPIPM throws no error and returns NaNs in the qp_out.

In this PR is the generated QP and its dimensions, such that the issue can be reproduced easily.