### PR TITLE
Use CMake option to find blasfeo (off by default to keep current behavior)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Options
 
+# Use CMake to find blasfeo
+set(HPIPM_FIND_BLASFEO OFF CACHE BOOL "Use CMake to find BLASFEO.")
+
 # Target architecture
 set(TARGET AVX CACHE STRING "Set CPU architecture target")
 #set(TARGET GENERIC CACHE STRING "Set CPU architecture target")
@@ -88,6 +91,11 @@ set(BUILD_SHARED_LIBS OFF CACHE STRING "Build shared libraries")
 if(NOT ${CMAKE_PROJECT_NAME} STREQUAL hpipm)
 	set(HPIPM_ALLOWED_TARGETS ${ALLOWED_TARGETS} PARENT_SCOPE)
 	set(HPIPM_ALLOWED_REF_BLAS ${ALLOWED_REF_BLAS} PARENT_SCOPE)
+endif()
+
+# Try to find blasfeo using CMake (also sets BLASFEO_PATH and BLASFEO_INCLUDE_DIR if found)
+if(HPIPM_FIND_BLASFEO)
+	find_package(blasfeo REQUIRED)
 endif()
 
 # BLASFEO Option


### PR DESCRIPTION
Here is a tiny change to the HPIPM build configuration. The default behavior is untouched. If a use wishes, it is now possible to let CMake find the BLASFEO installation details.

The newly introduced option is:
`HPIPM_FIND_BLASFEO` (default=`OFF`)

*Note*
If `HPIPM_FIND_BLASFEO==ON` and `blasfeo` is subsequently not found, then CMake will fail. If one would change the default value for `HPIPM_FIND_BLASFEO` to `ON`, then I recommend to relax this condition.