### PR TITLE
Dense QP Python interface

### DIFF
--- a/dense_qp/d_dense_qp.c
+++ b/dense_qp/d_dense_qp.c
@@ -75,6 +75,7 @@
 #define VECSC_LIBSTR blasfeo_dvecsc
 #define VECSE blasfeo_dvecse
 
+#define DENSE_QP_STRSIZE d_dense_qp_strsize
 #define DENSE_QP_MEMSIZE d_dense_qp_memsize
 #define DENSE_QP_CREATE d_dense_qp_create
 #define DENSE_QP_SET_ALL d_dense_qp_set_all

--- a/dense_qp/d_dense_qp_dim.c
+++ b/dense_qp/d_dense_qp_dim.c
@@ -45,6 +45,7 @@
 
 #define DENSE_QP_DIM d_dense_qp_dim
 
+#define DENSE_QP_DIM_STRSIZE d_dense_qp_dim_strsize
 #define DENSE_QP_DIM_MEMSIZE d_dense_qp_dim_memsize
 #define DENSE_QP_DIM_CREATE d_dense_qp_dim_create
 #define DENSE_QP_DIM_SET_ALL d_dense_qp_dim_set_all
@@ -56,6 +57,11 @@
 #define DENSE_QP_DIM_SET_NSB d_dense_qp_dim_set_nsb
 #define DENSE_QP_DIM_SET_NSG d_dense_qp_dim_set_nsg
 #define DENSE_QP_DIM_SET_NS d_dense_qp_dim_set_ns
+
+#define DENSE_QP_DIM_GET_NV d_dense_qp_dim_get_nv
+#define DENSE_QP_DIM_GET_NE d_dense_qp_dim_get_ne
+#define DENSE_QP_DIM_GET_NB d_dense_qp_dim_get_nb
+#define DENSE_QP_DIM_GET_NG d_dense_qp_dim_get_ng
 
 
 #include "x_dense_qp_dim.c"

--- a/dense_qp/d_dense_qp_ipm.c
+++ b/dense_qp/d_dense_qp_ipm.c
@@ -132,6 +132,7 @@
 
 
 // arg
+#define DENSE_QP_IPM_ARG_STRSIZE d_dense_qp_ipm_arg_strsize
 #define DENSE_QP_IPM_ARG_MEMSIZE d_dense_qp_ipm_arg_memsize
 #define DENSE_QP_IPM_ARG_CREATE d_dense_qp_ipm_arg_create
 #define DENSE_QP_IPM_ARG_SET_DEFAULT d_dense_qp_ipm_arg_set_default
@@ -159,6 +160,7 @@
 #define DENSE_QP_IPM_ARG_SET_SPLIT_STEP d_dense_qp_ipm_arg_set_split_step
 #define DENSE_QP_IPM_ARG_SET_T_LAM_MIN d_dense_qp_ipm_arg_set_t_lam_min
 // ipm
+#define DENSE_QP_IPM_WS_STRSIZE d_dense_qp_ipm_ws_strsize
 #define DENSE_QP_IPM_WS_MEMSIZE d_dense_qp_ipm_ws_memsize
 #define DENSE_QP_IPM_WS_CREATE d_dense_qp_ipm_ws_create
 #define DENSE_QP_IPM_GET d_dense_qp_ipm_get

--- a/dense_qp/d_dense_qp_sol.c
+++ b/dense_qp/d_dense_qp_sol.c
@@ -60,11 +60,17 @@
 #define SIZE_STRVEC blasfeo_memsize_dvec
 #define VECCP_LIBSTR blasfeo_dveccp
 
+#define DENSE_QP_SOL_STRSIZE d_dense_qp_sol_strsize
 #define DENSE_QP_SOL_MEMSIZE d_dense_qp_sol_memsize
 #define DENSE_QP_SOL_CREATE d_dense_qp_sol_create
 #define DENSE_QP_SOL_GET_ALL d_dense_qp_sol_get_all
 #define DENSE_QP_SOL_GET d_dense_qp_sol_get
 #define DENSE_QP_SOL_GET_V d_dense_qp_sol_get_v
+#define DENSE_QP_SOL_GET_PI d_dense_qp_sol_get_pi
+#define DENSE_QP_SOL_GET_LAM_LB d_dense_qp_sol_get_lam_lb
+#define DENSE_QP_SOL_GET_LAM_UB d_dense_qp_sol_get_lam_ub
+#define DENSE_QP_SOL_GET_LAM_LG d_dense_qp_sol_get_lam_lg
+#define DENSE_QP_SOL_GET_LAM_UG d_dense_qp_sol_get_lam_ug
 #define DENSE_QP_SOL_GET_VALID_OBJ d_dense_qp_sol_get_valid_obj
 #define DENSE_QP_SOL_GET_OBJ d_dense_qp_sol_get_obj
 

--- a/dense_qp/s_dense_qp_dim.c
+++ b/dense_qp/s_dense_qp_dim.c
@@ -45,6 +45,7 @@
 
 #define DENSE_QP_DIM s_dense_qp_dim
 
+#define DENSE_QP_DIM_STRSIZE s_dense_qp_dim_strsize
 #define DENSE_QP_DIM_MEMSIZE s_dense_qp_dim_memsize
 #define DENSE_QP_DIM_CREATE s_dense_qp_dim_create
 #define DENSE_QP_DIM_SET_ALL s_dense_qp_dim_set_all
@@ -57,7 +58,11 @@
 #define DENSE_QP_DIM_SET_NSG s_dense_qp_dim_set_nsg
 #define DENSE_QP_DIM_SET_NS s_dense_qp_dim_set_ns
 
+#define DENSE_QP_DIM_GET_NV s_dense_qp_dim_get_nv
+#define DENSE_QP_DIM_GET_NE s_dense_qp_dim_get_ne
+#define DENSE_QP_DIM_GET_NB s_dense_qp_dim_get_nb
+#define DENSE_QP_DIM_GET_NG s_dense_qp_dim_get_ng
+
 
 #include "x_dense_qp_dim.c"
-
 

--- a/dense_qp/s_dense_qp_sol.c
+++ b/dense_qp/s_dense_qp_sol.c
@@ -60,11 +60,17 @@
 #define SIZE_STRVEC blasfeo_memsize_svec
 #define VECCP_LIBSTR blasfeo_sveccp
 
+#define DENSE_QP_SOL_STRSIZE s_dense_qp_sol_strsize
 #define DENSE_QP_SOL_MEMSIZE s_dense_qp_sol_memsize
 #define DENSE_QP_SOL_CREATE s_dense_qp_sol_create
 #define DENSE_QP_SOL_GET_ALL s_dense_qp_sol_get_all
 #define DENSE_QP_SOL_GET s_dense_qp_sol_get
 #define DENSE_QP_SOL_GET_V s_dense_qp_sol_get_v
+#define DENSE_QP_SOL_GET_PI s_dense_qp_sol_get_pi
+#define DENSE_QP_SOL_GET_LAM_LB s_dense_qp_sol_get_lam_lb
+#define DENSE_QP_SOL_GET_LAM_UB s_dense_qp_sol_get_lam_ub
+#define DENSE_QP_SOL_GET_LAM_LG s_dense_qp_sol_get_lam_lg
+#define DENSE_QP_SOL_GET_LAM_UG s_dense_qp_sol_get_lam_ug
 #define DENSE_QP_SOL_GET_VALID_OBJ s_dense_qp_sol_get_valid_obj
 #define DENSE_QP_SOL_GET_OBJ s_dense_qp_sol_get_obj
 

--- a/dense_qp/x_dense_qp.c
+++ b/dense_qp/x_dense_qp.c
@@ -34,6 +34,11 @@
 **************************************************************************************************/
 
 
+hpipm_size_t DENSE_QP_STRSIZE()
+	{
+	return sizeof(struct DENSE_QP);
+	}
+
 
 hpipm_size_t DENSE_QP_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{

--- a/dense_qp/x_dense_qp_dim.c
+++ b/dense_qp/x_dense_qp_dim.c
@@ -34,6 +34,18 @@
 **************************************************************************************************/
 
 
+hpipm_size_t DENSE_QP_DIM_STRSIZE()
+	{
+
+	hpipm_size_t size = 0;
+
+	size += sizeof(struct DENSE_QP_DIM);
+
+	return size;
+
+	}
+
+
 
 hpipm_size_t DENSE_QP_DIM_MEMSIZE()
 	{
@@ -193,3 +205,37 @@ void DENSE_QP_DIM_SET_NS(int value, struct DENSE_QP_DIM *dim)
 	}
 
 
+
+void DENSE_QP_DIM_GET_NV(struct DENSE_QP_DIM *dim, int *value)
+	{
+	*value = dim->nv;
+
+	return;
+	}
+
+
+
+void DENSE_QP_DIM_GET_NE(struct DENSE_QP_DIM *dim, int *value)
+	{
+	*value = dim->ne;
+
+	return;
+	}
+
+
+
+void DENSE_QP_DIM_GET_NB(struct DENSE_QP_DIM *dim, int *value)
+	{
+	*value = dim->nb;
+
+	return;
+	}
+
+
+
+void DENSE_QP_DIM_GET_NG(struct DENSE_QP_DIM *dim, int *value)
+	{
+	*value = dim->ng;
+
+	return;
+	}

--- a/dense_qp/x_dense_qp_ipm.c
+++ b/dense_qp/x_dense_qp_ipm.c
@@ -34,6 +34,11 @@
 **************************************************************************************************/
 
 
+hpipm_size_t DENSE_QP_IPM_ARG_STRSIZE()
+	{
+	return sizeof(struct DENSE_QP_IPM_ARG);
+	}
+
 
 hpipm_size_t DENSE_QP_IPM_ARG_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
@@ -506,6 +511,11 @@ void DENSE_QP_IPM_ARG_SET_T_LAM_MIN(int *value, struct DENSE_QP_IPM_ARG *arg)
 	return;
 	}
 
+
+hpipm_size_t DENSE_QP_IPM_WS_STRSIZE()
+	{
+	return sizeof(struct DENSE_QP_IPM_WS);
+	}
 
 
 hpipm_size_t DENSE_QP_IPM_WS_MEMSIZE(struct DENSE_QP_DIM *dim, struct DENSE_QP_IPM_ARG *arg)

--- a/dense_qp/x_dense_qp_sol.c
+++ b/dense_qp/x_dense_qp_sol.c
@@ -34,6 +34,11 @@
 **************************************************************************************************/
 
 
+hpipm_size_t DENSE_QP_SOL_STRSIZE()
+	{
+	return sizeof(struct DENSE_QP_SOL);
+	}
+
 
 hpipm_size_t DENSE_QP_SOL_MEMSIZE(struct DENSE_QP_DIM *dim)
 	{
@@ -182,6 +187,26 @@ void DENSE_QP_SOL_GET(char *field, struct DENSE_QP_SOL *qp_sol, void *value)
 		{
 		DENSE_QP_SOL_GET_V(qp_sol, value);
 		}
+	else if(hpipm_strcmp(field, "pi"))
+		{
+		DENSE_QP_SOL_GET_PI(qp_sol, value);
+		}
+	else if(hpipm_strcmp(field, "lam_lb"))
+		{
+		DENSE_QP_SOL_GET_LAM_LB(qp_sol, value);
+		}
+	else if(hpipm_strcmp(field, "lam_ub"))
+		{
+		DENSE_QP_SOL_GET_LAM_UB(qp_sol, value);
+		}
+	else if(hpipm_strcmp(field, "lam_lg"))
+		{
+		DENSE_QP_SOL_GET_LAM_LG(qp_sol, value);
+		}
+	else if(hpipm_strcmp(field, "lam_ug"))
+		{
+		DENSE_QP_SOL_GET_LAM_UG(qp_sol, value);
+		}
 	else
 		{
 		printf("error: DENSE_QP_SOL_GET: wrong field name '%s'. Exiting.\n", field);
@@ -196,6 +221,49 @@ void DENSE_QP_SOL_GET_V(struct DENSE_QP_SOL *qp_sol, REAL *v)
 	{
 	int nv = qp_sol->dim->nv;
 	UNPACK_VEC(nv, qp_sol->v, 0, v, 1);
+	}
+
+
+
+void DENSE_QP_SOL_GET_PI(struct DENSE_QP_SOL *qp_sol, REAL *pi)
+	{
+	int ne = qp_sol->dim->ne;
+	UNPACK_VEC(ne, qp_sol->pi, 0, pi, 1);
+	}
+
+
+
+void DENSE_QP_SOL_GET_LAM_LB(struct DENSE_QP_SOL *qp_sol, REAL *lam_lb)
+	{
+	int nb = qp_sol->dim->nb;
+	UNPACK_VEC(nb, qp_sol->lam, 0, lam_lb, 1);
+	}
+
+
+
+void DENSE_QP_SOL_GET_LAM_UB(struct DENSE_QP_SOL *qp_sol, REAL *lam_ub)
+	{
+	int nb = qp_sol->dim->nb;
+	int ng = qp_sol->dim->ng;
+	UNPACK_VEC(nb, qp_sol->lam, nb+ng, lam_ub, 1);
+	}
+
+
+
+void DENSE_QP_SOL_GET_LAM_LG(struct DENSE_QP_SOL *qp_sol, REAL *lam_lg)
+	{
+	int nb = qp_sol->dim->nb;
+	int ng = qp_sol->dim->ng;
+	UNPACK_VEC(ng, qp_sol->lam, nb, lam_lg, 1);
+	}
+
+
+
+void DENSE_QP_SOL_GET_LAM_UG(struct DENSE_QP_SOL *qp_sol, REAL *lam_ug)
+	{
+	int nb = qp_sol->dim->nb;
+	int ng = qp_sol->dim->ng;
+	UNPACK_VEC(ng, qp_sol->lam, 2*nb+ng, lam_ug, 1);
 	}
 
 

--- a/examples/python/example_dense_qp_getting_started.py
+++ b/examples/python/example_dense_qp_getting_started.py
@@ -1,0 +1,169 @@
+###################################################################################################
+#                                                                                                 #
+# This file is part of HPIPM.                                                                     #
+#                                                                                                 #
+# HPIPM -- High-Performance Interior Point Method.                                                #
+# Copyright (C) 2019 by Gianluca Frison.                                                          #
+# Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              #
+# All rights reserved.                                                                            #
+#                                                                                                 #
+# The 2-Clause BSD License                                                                        #
+#                                                                                                 #
+# Redistribution and use in source and binary forms, with or without                              #
+# modification, are permitted provided that the following conditions are met:                     #
+#                                                                                                 #
+# 1. Redistributions of source code must retain the above copyright notice, this                  #
+#    list of conditions and the following disclaimer.                                             #
+# 2. Redistributions in binary form must reproduce the above copyright notice,                    #
+#    this list of conditions and the following disclaimer in the documentation                    #
+#    and/or other materials provided with the distribution.                                       #
+#                                                                                                 #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 #
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   #
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          #
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 #
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     #
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   #
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    #
+#                                                                                                 #
+# Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             #
+#                                                                                                 #
+###################################################################################################
+from hpipm_python import *
+from hpipm_python.common import *
+import numpy as np
+import time
+import sys
+import os
+
+
+
+# check that env.sh has been run
+env_run = os.getenv('ENV_RUN')
+if env_run!='true':
+	print('ERROR: env.sh has not been sourced! Before executing this example, run:')
+	print('source env.sh')
+	sys.exit(1)
+
+travis_run = os.getenv('TRAVIS_RUN')
+#travis_run = 'true'
+
+
+# dim
+nv = 3  # number of variables
+ne = 1  # number of equality constraints
+nb = 0  # number of box constraints
+ng = 3  # number of general (inequality) constraints
+
+dim = hpipm_dense_qp_dim()
+
+dim.set('nv', nv)
+dim.set('nb', nb)
+dim.set('ne', ne)
+dim.set('ng', ng)
+
+# print to shell
+# dim.print_C_struct()
+
+# this data is taken the from qpsolvers example
+# <https://github.com/qpsolvers/qpsolvers/blob/6f33bbc4ed797d92be1b88aa493a4398a8d8f73f/examples/quadratic_program.py>
+M = np.array([[1.0, 2.0, 0.0], [-8.0, 3.0, 2.0], [0.0, 1.0, 1.0]])
+H = np.dot(M.T, M)
+g = np.dot(np.array([3.0, 2.0, 3.0]), M)
+
+C = np.array([[1.0, 2.0, 1.0], [2.0, 0.0, 1.0], [-1.0, 2.0, -1.0]])
+d = np.array([3.0, 2.0, -2.0])
+A = np.array([[1.0, 1.0, 1.0]])
+b = np.array([1.0])
+
+# qp
+qp = hpipm_dense_qp(dim)
+
+# data
+qp.set('H', H)
+qp.set('g', g)
+qp.set('C', C)
+qp.set('ug', d)
+qp.set('lg', d)  # arbitrary
+qp.set('lg_mask', np.zeros(3))  # disable lower bound
+qp.set('A', A)
+qp.set('b', b)
+
+# print to shell
+# qp.print_C_struct()
+
+# qp sol
+qp_sol = hpipm_dense_qp_sol(dim)
+
+# set up solver arg
+#mode = 'speed_abs'
+mode = 'speed'
+#mode = 'balance'
+#mode = 'robust'
+# create and set default arg based on mode
+arg = hpipm_dense_qp_solver_arg(dim, mode)
+
+# create and set default arg based on mode
+arg.set('mu0', 1e4)
+arg.set('iter_max', 30)
+arg.set('tol_stat', 1e-4)
+arg.set('tol_eq', 1e-5)
+arg.set('tol_ineq', 1e-5)
+arg.set('tol_comp', 1e-5)
+arg.set('reg_prim', 1e-12)
+
+# set up solver
+solver = hpipm_dense_qp_solver(dim, arg)
+
+start_time = time.time()
+solver.solve(qp, qp_sol)
+end_time = time.time()
+if(travis_run!='true'):
+	print('solve time {:e}'.format(end_time-start_time))
+
+v = qp_sol.get('v')
+pi = qp_sol.get('pi')
+lam_lb = qp_sol.get('lam_lb')
+lam_ub = qp_sol.get('lam_ub')
+lam_lg = qp_sol.get('lam_lg')
+lam_ug = qp_sol.get('lam_ug')
+print('v      = {}'.format(v.flatten()))
+print('pi     = {}'.format(pi.flatten()))
+print('lam_lb = {}'.format(lam_lb.flatten()))
+print('lam_ub = {}'.format(lam_ub.flatten()))
+print('lam_lg = {}'.format(lam_lg.flatten()))
+print('lam_ug = {}'.format(lam_ug.flatten()))
+
+# get solver statistics
+status = solver.get('status')
+res_stat = solver.get('max_res_stat')
+res_eq = solver.get('max_res_eq')
+res_ineq = solver.get('max_res_ineq')
+res_comp = solver.get('max_res_comp')
+iters = solver.get('iter')
+stat = solver.get('stat')
+if(travis_run!='true'):
+	print('\nsolver statistics:\n')
+	print('ipm return = {0:1d}\n'.format(status))
+	print('ipm max res stat = {:e}\n'.format(res_stat))
+	print('ipm max res eq   = {:e}\n'.format(res_eq))
+	print('ipm max res ineq = {:e}\n'.format(res_ineq))
+	print('ipm max res comp = {:e}\n'.format(res_comp))
+	print('ipm iter = {0:1d}\n'.format(iters))
+	print('stat =')
+	print('\titer\talpha_aff\tmu_aff\t\tsigma\t\talpha_prim\talpha_dual\tmu\t\tres_stat\tres_eq\t\tres_ineq\tres_comp')
+	for ii in range(iters+1):
+		print('\t{:d}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}\t{:e}'.format(ii, stat[ii][0], stat[ii][1], stat[ii][2], stat[ii][3], stat[ii][4], stat[ii][5], stat[ii][6], stat[ii][7], stat[ii][8], stat[ii][9]))
+	print('')
+
+if status==0:
+	print('\nsuccess!\n')
+else:
+	print('\nSolution failed, solver returned status {0:1d}\n'.format(status))
+
+
+
+sys.exit(int(status))

--- a/include/hpipm_d_dense_qp.h
+++ b/include/hpipm_d_dense_qp.h
@@ -73,6 +73,8 @@ struct d_dense_qp
 
 
 //
+hpipm_size_t d_dense_qp_strsize();
+//
 hpipm_size_t d_dense_qp_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_create(struct d_dense_qp_dim *dim, struct d_dense_qp *qp, void *memory);

--- a/include/hpipm_d_dense_qp_dim.h
+++ b/include/hpipm_d_dense_qp_dim.h
@@ -59,6 +59,8 @@ struct d_dense_qp_dim
 
 
 //
+hpipm_size_t d_dense_qp_dim_strsize();
+//
 hpipm_size_t d_dense_qp_dim_memsize();
 //
 void d_dense_qp_dim_create(struct d_dense_qp_dim *qp_dim, void *memory);
@@ -81,6 +83,15 @@ void d_dense_qp_dim_set_nsg(int value, struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_dim_set_ns(int value, struct d_dense_qp_dim *dim);
 
+// getters
+//
+void d_dense_qp_dim_get_nv(struct d_dense_qp_dim *dim, int *value);
+//
+void d_dense_qp_dim_get_ne(struct d_dense_qp_dim *dim, int *value);
+//
+void d_dense_qp_dim_get_nb(struct d_dense_qp_dim *dim, int *value);
+//
+void d_dense_qp_dim_get_ng(struct d_dense_qp_dim *dim, int *value);
 
 
 #ifdef __cplusplus

--- a/include/hpipm_d_dense_qp_ipm.h
+++ b/include/hpipm_d_dense_qp_ipm.h
@@ -158,7 +158,8 @@ struct d_dense_qp_ipm_ws
 	};
 
 
-
+//
+hpipm_size_t d_dense_qp_ipm_arg_strsize();
 //
 hpipm_size_t d_dense_qp_ipm_arg_memsize(struct d_dense_qp_dim *dim);
 //
@@ -213,6 +214,8 @@ void d_dense_qp_ipm_arg_set_t_lam_min(int *value, struct d_dense_qp_ipm_arg *arg
 //
 void d_dense_qp_ipm_arg_set_split_step(int *value, struct d_dense_qp_ipm_arg *arg);
 
+//
+hpipm_size_t d_dense_qp_ipm_ws_strsize();
 //
 hpipm_size_t d_dense_qp_ipm_ws_memsize(struct d_dense_qp_dim *qp_dim, struct d_dense_qp_ipm_arg *arg);
 //

--- a/include/hpipm_d_dense_qp_sol.h
+++ b/include/hpipm_d_dense_qp_sol.h
@@ -69,6 +69,8 @@ struct d_dense_qp_sol
 
 
 //
+hpipm_size_t d_dense_qp_sol_strsize();
+//
 hpipm_size_t d_dense_qp_sol_memsize(struct d_dense_qp_dim *dim);
 //
 void d_dense_qp_sol_create(struct d_dense_qp_dim *dim, struct d_dense_qp_sol *qp_sol, void *memory);
@@ -78,6 +80,16 @@ void d_dense_qp_sol_get_all(struct d_dense_qp_sol *qp_sol, double *v, double *ls
 void d_dense_qp_sol_get(char *field, struct d_dense_qp_sol *sol, void *value);
 //
 void d_dense_qp_sol_get_v(struct d_dense_qp_sol *sol, double *v);
+//
+void d_dense_qp_sol_get_pi(struct d_dense_qp_sol *sol, double *pi);
+//
+void d_dense_qp_sol_get_lam_lb(struct d_dense_qp_sol *sol, double *lam_lb);
+//
+void d_dense_qp_sol_get_lam_ub(struct d_dense_qp_sol *sol, double *lam_ub);
+//
+void d_dense_qp_sol_get_lam_lg(struct d_dense_qp_sol *sol, double *lam_lg);
+//
+void d_dense_qp_sol_get_lam_ug(struct d_dense_qp_sol *sol, double *lam_ug);
 //
 void d_dense_qp_sol_get_valid_obj(struct d_dense_qp_sol *sol, int *valid_obj);
 //

--- a/include/hpipm_s_dense_qp_dim.h
+++ b/include/hpipm_s_dense_qp_dim.h
@@ -59,6 +59,8 @@ struct s_dense_qp_dim
 
 
 //
+hpipm_size_t s_dense_qp_dim_strsize();
+//
 hpipm_size_t s_dense_qp_dim_memsize();
 //
 void s_dense_qp_dim_create(struct s_dense_qp_dim *qp_dim, void *memory);
@@ -81,6 +83,15 @@ void s_dense_qp_dim_set_nsg(int value, struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_dim_set_ns(int value, struct s_dense_qp_dim *dim);
 
+// getters
+//
+void s_dense_qp_dim_get_nv(struct s_dense_qp_dim *dim, int *value);
+//
+void s_dense_qp_dim_get_ne(struct s_dense_qp_dim *dim, int *value);
+//
+void s_dense_qp_dim_get_nb(struct s_dense_qp_dim *dim, int *value);
+//
+void s_dense_qp_dim_get_ng(struct s_dense_qp_dim *dim, int *value);
 
 
 #ifdef __cplusplus

--- a/include/hpipm_s_dense_qp_sol.h
+++ b/include/hpipm_s_dense_qp_sol.h
@@ -69,6 +69,8 @@ struct s_dense_qp_sol
 
 
 //
+hpipm_size_t s_dense_qp_sol_strsize();
+//
 hpipm_size_t s_dense_qp_sol_memsize(struct s_dense_qp_dim *dim);
 //
 void s_dense_qp_sol_create(struct s_dense_qp_dim *dim, struct s_dense_qp_sol *qp_sol, void *memory);
@@ -78,6 +80,16 @@ void s_dense_qp_sol_get_all(struct s_dense_qp_sol *qp_sol, float *v, float *ls, 
 void s_dense_qp_sol_get(char *field, struct s_dense_qp_sol *sol, void *value);
 //
 void s_dense_qp_sol_get_v(struct s_dense_qp_sol *sol, float *v);
+//
+void s_dense_qp_sol_get_pi(struct s_dense_qp_sol *sol, float *pi);
+//
+void s_dense_qp_sol_get_lam_lb(struct s_dense_qp_sol *sol, float *lam_lb);
+//
+void s_dense_qp_sol_get_lam_ub(struct s_dense_qp_sol *sol, float *lam_ub);
+//
+void s_dense_qp_sol_get_lam_lg(struct s_dense_qp_sol *sol, float *lam_lg);
+//
+void s_dense_qp_sol_get_lam_ug(struct s_dense_qp_sol *sol, float *lam_ug);
 //
 void s_dense_qp_sol_get_valid_obj(struct s_dense_qp_sol *sol, int *valid_obj);
 //

--- a/interfaces/python/hpipm_python/hpipm_python/common.py
+++ b/interfaces/python/hpipm_python/hpipm_python/common.py
@@ -45,3 +45,9 @@ from .wrapper.hpipm_ocp_qcqp_sol import *
 from .wrapper.hpipm_ocp_qcqp_dim import *
 from .wrapper.hpipm_ocp_qcqp_solver import *
 from .wrapper.hpipm_ocp_qcqp_solver_arg import *
+# dense qp
+from .wrapper.hpipm_dense_qp import *
+from .wrapper.hpipm_dense_qp_sol import *
+from .wrapper.hpipm_dense_qp_dim import *
+from .wrapper.hpipm_dense_qp_solver import *
+from .wrapper.hpipm_dense_qp_solver_arg import *

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp.py
@@ -34,7 +34,7 @@
 ###################################################################################################
 
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
@@ -61,7 +61,6 @@ class hpipm_dense_qp:
 		# create C qp
 		__hpipm.d_dense_qp_create(dim.dim_struct, qp_struct, qp_mem)
 
-
 	def set(self, field, value):
 		# cast to np array
 		if type(value) is not np.ndarray:
@@ -81,14 +80,5 @@ class hpipm_dense_qp:
 		self.__hpipm.d_dense_qp_set(c_char_p(field_name_b), tmp, self.qp_struct)
 		return
 
-
 	def print_C_struct(self):
 		self.__hpipm.d_dense_qp_print(self.dim.dim_struct, self.qp_struct)
-
-
-	def codegen(self, file_name, mode):
-		file_name_b = file_name.encode('utf-8')
-		mode_b = mode.encode('utf-8')
-		self.__hpipm.d_dense_qp_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim.dim_struct, self.qp_struct)
-		return 
-

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp.py
@@ -1,0 +1,94 @@
+###################################################################################################
+#												  #
+# This file is part of HPIPM.									  #
+#												  #
+# HPIPM -- High-Performance Interior Point Method.						  #
+# Copyright (C) 2019 by Gianluca Frison.							  #
+# Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.		  #
+# All rights reserved.										  #
+#												  #
+# The 2-Clause BSD License									  #
+#												  #
+# Redistribution and use in source and binary forms, with or without				  #
+# modification, are permitted provided that the following conditions are met:			  #
+#												  #
+# 1. Redistributions of source code must retain the above copyright notice, this		  #
+#    list of conditions and the following disclaimer.						  #
+# 2. Redistributions in binary form must reproduce the above copyright notice,			  #
+#    this list of conditions and the following disclaimer in the documentation			  #
+#    and/or other materials provided with the distribution.					  #
+#												  #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND		  #
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED			  #
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE			  #
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR		  #
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES		  #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;			  #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND			  #
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT			  #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS			  #
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.					  #
+#												  #
+# Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de				  #
+#												  #
+###################################################################################################
+
+from ctypes import *
+import ctypes.util 
+import numpy as np
+
+
+class hpipm_dense_qp:
+	def __init__(self, dim):
+
+		# save dim internally
+		self.dim = dim
+
+		# load hpipm shared library
+		__hpipm   = CDLL('libhpipm.so')
+		self.__hpipm = __hpipm
+
+		# C qp struct
+		qp_struct_size = __hpipm.d_dense_qp_strsize()
+		qp_struct = cast(create_string_buffer(qp_struct_size), c_void_p)
+		self.qp_struct = qp_struct
+
+		# C qp internal memory
+		qp_mem_size = __hpipm.d_dense_qp_memsize(dim.dim_struct)
+		qp_mem = cast(create_string_buffer(qp_mem_size), c_void_p)
+		self.qp_mem = qp_mem
+
+		# create C qp
+		__hpipm.d_dense_qp_create(dim.dim_struct, qp_struct, qp_mem)
+
+
+	def set(self, field, value):
+		# cast to np array
+		if type(value) is not np.ndarray:
+			if (type(value) is int) or (type(value) is float):
+				value_ = value
+				value = np.array((1,))
+				value[0] = value_
+		# convert into column-major
+		value_cm = np.ravel(value, 'F')
+		if(field=='idxbx' or field=='idxbu' or field=='idxb' or field=='idxs' or field=='idxs_rev' or field=='idxe' or field=='idxbue' or field=='idxbxe' or field=='idxge'):
+			value_cm = np.ascontiguousarray(value_cm, dtype=np.int32)
+			tmp = cast(value_cm.ctypes.data, POINTER(c_int))
+		else:
+			value_cm = np.ascontiguousarray(value_cm, dtype=np.float64)
+			tmp = cast(value_cm.ctypes.data, POINTER(c_double))
+		field_name_b = field.encode('utf-8')
+		self.__hpipm.d_dense_qp_set(c_char_p(field_name_b), tmp, self.qp_struct)
+		return
+
+
+	def print_C_struct(self):
+		self.__hpipm.d_dense_qp_print(self.dim.dim_struct, self.qp_struct)
+
+
+	def codegen(self, file_name, mode):
+		file_name_b = file_name.encode('utf-8')
+		mode_b = mode.encode('utf-8')
+		self.__hpipm.d_dense_qp_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim.dim_struct, self.qp_struct)
+		return 
+

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_dim.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_dim.py
@@ -1,0 +1,81 @@
+###################################################################################################
+#												  #
+# This file is part of HPIPM.									  #
+#												  #
+# HPIPM -- High-Performance Interior Point Method.						  #
+# Copyright (C) 2019 by Gianluca Frison.							  #
+# Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.		  #
+# All rights reserved.										  #
+#												  #
+# The 2-Clause BSD License									  #
+#												  #
+# Redistribution and use in source and binary forms, with or without				  #
+# modification, are permitted provided that the following conditions are met:			  #
+#												  #
+# 1. Redistributions of source code must retain the above copyright notice, this		  #
+#    list of conditions and the following disclaimer.						  #
+# 2. Redistributions in binary form must reproduce the above copyright notice,			  #
+#    this list of conditions and the following disclaimer in the documentation			  #
+#    and/or other materials provided with the distribution.					  #
+#												  #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND		  #
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED			  #
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE			  #
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR		  #
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES		  #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;			  #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND			  #
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT			  #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS			  #
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.					  #
+#												  #
+# Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de				  #
+#												  #
+###################################################################################################
+
+from ctypes import *
+import ctypes.util 
+import numpy as np
+
+
+class hpipm_dense_qp_dim:
+
+
+	def __init__(self):
+
+		# load hpipm shared library
+		__hpipm   = CDLL('libhpipm.so')
+		self.__hpipm = __hpipm
+
+		# C dim struct
+		dim_struct_size = __hpipm.d_dense_qp_dim_strsize()
+		dim_struct = cast(create_string_buffer(dim_struct_size), c_void_p)
+		self.dim_struct = dim_struct
+
+		# C dim internal memory
+		dim_mem_size = __hpipm.d_dense_qp_dim_memsize()
+		dim_mem = cast(create_string_buffer(dim_mem_size), c_void_p)
+		self.dim_mem = dim_mem
+
+		# create C dim
+		__hpipm.d_dense_qp_dim_create(self.dim_struct, self.dim_mem)
+
+
+	def set(self, field, value):
+		self.__hpipm.d_dense_qp_dim_set.argtypes = [c_char_p, c_int, c_void_p]
+		field_name_b = field.encode('utf-8')
+		self.__hpipm.d_dense_qp_dim_set(c_char_p(field_name_b), value, self.dim_struct)
+		return
+
+
+	def print_C_struct(self):
+		self.__hpipm.d_dense_qp_dim_print(self.dim_struct)
+		return 
+
+
+	def codegen(self, file_name, mode):
+		file_name_b = file_name.encode('utf-8')
+		mode_b = mode.encode('utf-8')
+		self.__hpipm.d_dense_qp_dim_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim_struct)
+		return 
+

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_dim.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_dim.py
@@ -34,13 +34,11 @@
 ###################################################################################################
 
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
 class hpipm_dense_qp_dim:
-
-
 	def __init__(self):
 
 		# load hpipm shared library
@@ -60,22 +58,12 @@ class hpipm_dense_qp_dim:
 		# create C dim
 		__hpipm.d_dense_qp_dim_create(self.dim_struct, self.dim_mem)
 
-
 	def set(self, field, value):
 		self.__hpipm.d_dense_qp_dim_set.argtypes = [c_char_p, c_int, c_void_p]
 		field_name_b = field.encode('utf-8')
 		self.__hpipm.d_dense_qp_dim_set(c_char_p(field_name_b), value, self.dim_struct)
 		return
 
-
 	def print_C_struct(self):
 		self.__hpipm.d_dense_qp_dim_print(self.dim_struct)
-		return 
-
-
-	def codegen(self, file_name, mode):
-		file_name_b = file_name.encode('utf-8')
-		mode_b = mode.encode('utf-8')
-		self.__hpipm.d_dense_qp_dim_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim_struct)
-		return 
-
+		return

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
@@ -1,0 +1,116 @@
+###################################################################################################
+#												  #
+# This file is part of HPIPM.									  #
+#												  #
+# HPIPM -- High-Performance Interior Point Method.						  #
+# Copyright (C) 2019 by Gianluca Frison.							  #
+# Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.		  #
+# All rights reserved.										  #
+#												  #
+# The 2-Clause BSD License									  #
+#												  #
+# Redistribution and use in source and binary forms, with or without				  #
+# modification, are permitted provided that the following conditions are met:			  #
+#												  #
+# 1. Redistributions of source code must retain the above copyright notice, this		  #
+#    list of conditions and the following disclaimer.						  #
+# 2. Redistributions in binary form must reproduce the above copyright notice,			  #
+#    this list of conditions and the following disclaimer in the documentation			  #
+#    and/or other materials provided with the distribution.					  #
+#												  #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND		  #
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED			  #
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE			  #
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR		  #
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES		  #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;			  #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND			  #
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT			  #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS			  #
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.					  #
+#												  #
+# Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de				  #
+#												  #
+###################################################################################################
+
+from ctypes import *
+import ctypes.util
+import numpy as np
+
+
+
+class hpipm_dense_qp_sol:
+
+
+	def __init__(self, dim):
+
+		# save dim internally
+		self.dim = dim
+
+		# load hpipm shared library
+		__hpipm   = CDLL('libhpipm.so')
+		self.__hpipm = __hpipm
+
+		# C qp struct
+		qp_sol_struct_size = __hpipm.d_dense_qp_sol_strsize()
+		qp_sol_struct = cast(create_string_buffer(qp_sol_struct_size), c_void_p)
+		self.qp_sol_struct = qp_sol_struct
+
+		# C qp internal memory
+		qp_sol_mem_size = __hpipm.d_dense_qp_sol_memsize(dim.dim_struct)
+		qp_sol_mem = cast(create_string_buffer(qp_sol_mem_size), c_void_p)
+		self.qp_sol_mem = qp_sol_mem
+
+		# create C qp
+		__hpipm.d_dense_qp_sol_create(dim.dim_struct, qp_sol_struct, qp_sol_mem)
+
+		# getter functions for primals, duals, and slacks
+		self.__getters = {
+			'v': {
+				'n_var': __hpipm.d_dense_qp_dim_get_nv,
+				'var': __hpipm.d_dense_qp_sol_get_v
+			},
+			'pi': {
+				'n_var': __hpipm.d_dense_qp_dim_get_ne,
+				'var': __hpipm.d_dense_qp_sol_get_pi
+			},
+			'lam_lb': {
+				'n_var': __hpipm.d_dense_qp_dim_get_nb,
+				'var': __hpipm.d_dense_qp_sol_get_lam_lb
+			},
+			'lam_ub': {
+				'n_var': __hpipm.d_dense_qp_dim_get_nb,
+				'var': __hpipm.d_dense_qp_sol_get_lam_ub
+			},
+			'lam_lg': {
+				'n_var': __hpipm.d_dense_qp_dim_get_ng,
+				'var': __hpipm.d_dense_qp_sol_get_lam_lg
+			},
+			'lam_ug': {
+				'n_var': __hpipm.d_dense_qp_dim_get_ng,
+				'var': __hpipm.d_dense_qp_sol_get_lam_ug
+			}
+		}
+
+	def get(self, field):
+		if field not in self.__getters:
+			raise NameError('hpipm_dense_qp_sol.get: wrong field')
+		else:
+			return self.__get(self.__getters[field])
+
+	def __get(self, getter):
+		# number of variables
+		n_var = np.zeros((1,1), dtype=int)
+
+		tmp_ptr = cast(n_var.ctypes.data, POINTER(c_int))
+		getter['n_var'](self.dim.dim_struct, tmp_ptr)
+
+		var = np.zeros((n_var[0,0], 1))
+		tmp_ptr = cast(var.ctypes.data, POINTER(c_double))
+		getter['var'](self.qp_sol_struct, tmp_ptr)
+
+		return var
+
+	def print_C_struct(self):
+		self.__hpipm.d_dense_qp_sol_print(self.dim.dim_struct, self.qp_sol_struct)
+		return

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
@@ -38,10 +38,7 @@ import ctypes.util
 import numpy as np
 
 
-
 class hpipm_dense_qp_sol:
-
-
 	def __init__(self, dim):
 
 		# save dim internally

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver.py
@@ -33,21 +33,71 @@
 #                                                                                                 #
 ###################################################################################################
 
-# ocp qp
-from .hpipm_ocp_qp import *
-from .hpipm_ocp_qp_sol import *
-from .hpipm_ocp_qp_dim import *
-from .hpipm_ocp_qp_solver import *
-from .hpipm_ocp_qp_solver_arg import *
-# ocp qcqp
-from .hpipm_ocp_qcqp import *
-from .hpipm_ocp_qcqp_sol import *
-from .hpipm_ocp_qcqp_dim import *
-from .hpipm_ocp_qcqp_solver import *
-from .hpipm_ocp_qcqp_solver_arg import *
-# dense qp
-from .hpipm_dense_qp import *
-from .hpipm_dense_qp_sol import *
-from .hpipm_dense_qp_dim import *
-from .hpipm_dense_qp_solver import *
-from .hpipm_dense_qp_solver_arg import *
+from ctypes import *
+import ctypes.util 
+import numpy as np
+
+
+
+class hpipm_dense_qp_solver:
+
+
+	def __init__(self, qp_dims, arg):
+
+		# load hpipm shared library
+		__hpipm   = CDLL('libhpipm.so')
+		self.__hpipm = __hpipm
+
+		# set up ipm workspace struct
+		sizeof_d_dense_qp_ipm_workspace = __hpipm.d_dense_qp_ipm_ws_strsize()
+		ipm_ws_struct = cast(create_string_buffer(sizeof_d_dense_qp_ipm_workspace), c_void_p)
+		self.ipm_ws_struct = ipm_ws_struct
+
+		# allocate memory for ipm workspace 
+		ipm_size = __hpipm.d_dense_qp_ipm_ws_memsize(qp_dims.dim_struct, arg.arg_struct)
+		ipm_ws_mem = cast(create_string_buffer(ipm_size), c_void_p)
+		self.ipm_ws_mem = ipm_ws_mem
+
+		# create C ws
+		__hpipm.d_dense_qp_ipm_ws_create(qp_dims.dim_struct, arg.arg_struct, ipm_ws_struct, ipm_ws_mem)
+
+		self.arg = arg
+		self.dim_struct = qp_dims.dim_struct
+
+	def solve(self, qp, qp_sol):
+		self.__hpipm.d_dense_qp_ipm_solve(qp.qp_struct, qp_sol.qp_sol_struct, self.arg.arg_struct, self.ipm_ws_struct)
+
+	def get(self, field):
+		if((field=='stat')):
+			# get iters
+			iters = np.zeros((1,1), dtype=int);
+			tmp = cast(iters.ctypes.data, POINTER(c_int))
+			self.__hpipm.d_dense_qp_ipm_get_iter(self.ipm_ws_struct, tmp)
+			# get stat_m
+			stat_m = np.zeros((1,1), dtype=int);
+			tmp = cast(stat_m.ctypes.data, POINTER(c_int))
+			self.__hpipm.d_dense_qp_ipm_get_stat_m(self.ipm_ws_struct, tmp)
+			# get stat pointer
+			res = np.zeros((iters[0][0]+1, stat_m[0][0]));
+			ptr = c_void_p()
+			self.__hpipm.d_dense_qp_ipm_get_stat(self.ipm_ws_struct, byref(ptr))
+			tmp = cast(ptr, POINTER(c_double))
+			for ii in range(iters[0][0]+1):
+				for jj in range(stat_m[0][0]):
+					res[ii][jj] = tmp[jj+ii*stat_m[0][0]]
+					res[ii][jj] = tmp[jj+ii*stat_m[0][0]]
+			return res
+		elif((field=='status') | (field=='iter')):
+			res = np.zeros((1,1), dtype=int);
+			tmp = cast(res.ctypes.data, POINTER(c_int))
+		elif((field=='max_res_stat') | (field=='max_res_eq') | (field=='max_res_ineq') | (field=='max_res_comp')):
+			res = np.zeros((1,1));
+			tmp = cast(res.ctypes.data, POINTER(c_double))
+		else:
+			raise NameError('hpipm_dense_qp_solver.get: wrong field')
+		field_name_b = field.encode('utf-8')
+		self.__hpipm.d_dense_qp_ipm_get(c_char_p(field_name_b), self.ipm_ws_struct, tmp)
+		return res[0][0]
+
+
+

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver.py
@@ -34,14 +34,11 @@
 ###################################################################################################
 
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
-
 class hpipm_dense_qp_solver:
-
-
 	def __init__(self, qp_dims, arg):
 
 		# load hpipm shared library
@@ -53,7 +50,7 @@ class hpipm_dense_qp_solver:
 		ipm_ws_struct = cast(create_string_buffer(sizeof_d_dense_qp_ipm_workspace), c_void_p)
 		self.ipm_ws_struct = ipm_ws_struct
 
-		# allocate memory for ipm workspace 
+		# allocate memory for ipm workspace
 		ipm_size = __hpipm.d_dense_qp_ipm_ws_memsize(qp_dims.dim_struct, arg.arg_struct)
 		ipm_ws_mem = cast(create_string_buffer(ipm_size), c_void_p)
 		self.ipm_ws_mem = ipm_ws_mem
@@ -98,6 +95,3 @@ class hpipm_dense_qp_solver:
 		field_name_b = field.encode('utf-8')
 		self.__hpipm.d_dense_qp_ipm_get(c_char_p(field_name_b), self.ipm_ws_struct, tmp)
 		return res[0][0]
-
-
-

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
@@ -33,14 +33,11 @@
 #                                                                                                 #
 ###################################################################################################
 from ctypes import *
-import ctypes.util 
+import ctypes.util
 import numpy as np
 
 
-
 class hpipm_dense_qp_solver_arg:
-
-
 	def __init__(self, dim, mode):
 
 		c_mode = 0
@@ -77,7 +74,6 @@ class hpipm_dense_qp_solver_arg:
 
 		# initialize default arguments
 		__hpipm.d_dense_qp_ipm_arg_set_default(c_mode, arg_struct) # mode==SPEED
-	
 
 	def set(self, field, value):
 		if((field=='mu0') | (field=='tol_stat') | (field=='tol_eq') | (field=='tol_ineq') | (field=='tol_comp') | (field=='reg_prim')):
@@ -93,11 +89,3 @@ class hpipm_dense_qp_solver_arg:
 		field_name_b = field.encode('utf-8')
 		self.__hpipm.d_dense_qp_ipm_arg_set(c_char_p(field_name_b), tmp, self.arg_struct)
 		return
-
-
-	def codegen(self, file_name, mode):
-		file_name_b = file_name.encode('utf-8')
-		mode_b = mode.encode('utf-8')
-		self.__hpipm.d_dense_qp_ipm_arg_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim.dim_struct, self.arg_struct)
-		return 
-

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
@@ -32,22 +32,72 @@
 # Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             #
 #                                                                                                 #
 ###################################################################################################
+from ctypes import *
+import ctypes.util 
+import numpy as np
 
-# ocp qp
-from .hpipm_ocp_qp import *
-from .hpipm_ocp_qp_sol import *
-from .hpipm_ocp_qp_dim import *
-from .hpipm_ocp_qp_solver import *
-from .hpipm_ocp_qp_solver_arg import *
-# ocp qcqp
-from .hpipm_ocp_qcqp import *
-from .hpipm_ocp_qcqp_sol import *
-from .hpipm_ocp_qcqp_dim import *
-from .hpipm_ocp_qcqp_solver import *
-from .hpipm_ocp_qcqp_solver_arg import *
-# dense qp
-from .hpipm_dense_qp import *
-from .hpipm_dense_qp_sol import *
-from .hpipm_dense_qp_dim import *
-from .hpipm_dense_qp_solver import *
-from .hpipm_dense_qp_solver_arg import *
+
+
+class hpipm_dense_qp_solver_arg:
+
+
+	def __init__(self, dim, mode):
+
+		c_mode = 0
+		if(mode=='speed_abs'):
+			c_mode = 0
+		elif(mode=='speed'):
+			c_mode = 1
+		elif(mode=='balance'):
+			c_mode = 2
+		elif(mode=='robust'):
+			c_mode = 3
+		else:
+			raise NameError('hpipm_dense_qp_solver_arg: wrong mode')
+
+		# save dim internally
+		self.dim = dim
+
+		# load hpipm shared library
+		__hpipm   = CDLL('libhpipm.so')
+		self.__hpipm = __hpipm
+
+		# C qp struct
+		arg_struct_size = __hpipm.d_dense_qp_ipm_arg_strsize()
+		arg_struct = cast(create_string_buffer(arg_struct_size), c_void_p)
+		self.arg_struct = arg_struct
+
+		# C qp internal memory
+		arg_mem_size = __hpipm.d_dense_qp_ipm_arg_memsize(dim.dim_struct)
+		arg_mem = cast(create_string_buffer(arg_mem_size), c_void_p)
+		self.arg_mem = arg_mem
+
+		# create C qp
+		__hpipm.d_dense_qp_ipm_arg_create(dim.dim_struct, arg_struct, arg_mem)
+
+		# initialize default arguments
+		__hpipm.d_dense_qp_ipm_arg_set_default(c_mode, arg_struct) # mode==SPEED
+	
+
+	def set(self, field, value):
+		if((field=='mu0') | (field=='tol_stat') | (field=='tol_eq') | (field=='tol_ineq') | (field=='tol_comp') | (field=='reg_prim')):
+			tmp_in = np.zeros((1,1))
+			tmp_in[0][0] = value
+			tmp = cast(tmp_in.ctypes.data, POINTER(c_double))
+		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step')):
+			tmp_in = np.zeros((1,1), dtype=int)
+			tmp_in[0][0] = value
+			tmp = cast(tmp_in.ctypes.data, POINTER(c_int))
+		else:
+			raise NameError('hpipm_dense_qp_solver_arg.set: wrong field')
+		field_name_b = field.encode('utf-8')
+		self.__hpipm.d_dense_qp_ipm_arg_set(c_char_p(field_name_b), tmp, self.arg_struct)
+		return
+
+
+	def codegen(self, file_name, mode):
+		file_name_b = file_name.encode('utf-8')
+		mode_b = mode.encode('utf-8')
+		self.__hpipm.d_dense_qp_ipm_arg_codegen(c_char_p(file_name_b), c_char_p(mode_b), self.dim.dim_struct, self.arg_struct)
+		return 
+


### PR DESCRIPTION
The main goal of this PR is to provide a Python interface for the dense QP API, similar to the OCP QP interface. This would make it easier to quickly try out HPIPM as a general QP solver in Python.

In addition to the interface and a basic example, I added some getters to the dense QP API to allow more information to be exposed to Python. Notably, the dual multipliers of the solution (for equalities, box inequalities, and general inequalities) are exposed. I have not exposed the values of the slack variables or their corresponding dual multipliers, but that could be easily done.

Let me know what you think.