### PR TITLE
Primal warm-start in dense QP Python interface

### DIFF
--- a/dense_qp/d_dense_qp_sol.c
+++ b/dense_qp/d_dense_qp_sol.c
@@ -52,6 +52,7 @@
 
 #define CREATE_STRVEC blasfeo_create_dvec
 #define UNPACK_VEC blasfeo_unpack_dvec
+#define PACK_VEC blasfeo_pack_dvec
 #define DENSE_QP d_dense_qp
 #define DENSE_QP_DIM d_dense_qp_dim
 #define DENSE_QP_SOL d_dense_qp_sol
@@ -73,6 +74,7 @@
 #define DENSE_QP_SOL_GET_LAM_UG d_dense_qp_sol_get_lam_ug
 #define DENSE_QP_SOL_GET_VALID_OBJ d_dense_qp_sol_get_valid_obj
 #define DENSE_QP_SOL_GET_OBJ d_dense_qp_sol_get_obj
+#define DENSE_QP_SOL_SET_V d_dense_qp_sol_set_v
 
 
 

--- a/dense_qp/s_dense_qp_sol.c
+++ b/dense_qp/s_dense_qp_sol.c
@@ -52,6 +52,7 @@
 
 #define CREATE_STRVEC blasfeo_create_svec
 #define UNPACK_VEC blasfeo_unpack_svec
+#define PACK_VEC blasfeo_pack_svec
 #define DENSE_QP s_dense_qp
 #define DENSE_QP_DIM s_dense_qp_dim
 #define DENSE_QP_SOL s_dense_qp_sol
@@ -73,6 +74,7 @@
 #define DENSE_QP_SOL_GET_LAM_UG s_dense_qp_sol_get_lam_ug
 #define DENSE_QP_SOL_GET_VALID_OBJ s_dense_qp_sol_get_valid_obj
 #define DENSE_QP_SOL_GET_OBJ s_dense_qp_sol_get_obj
+#define DENSE_QP_SOL_SET_V s_dense_qp_sol_set_v
 
 
 

--- a/dense_qp/x_dense_qp_sol.c
+++ b/dense_qp/x_dense_qp_sol.c
@@ -279,3 +279,11 @@ void DENSE_QP_SOL_GET_OBJ(struct DENSE_QP_SOL *qp_sol, REAL *obj)
 	{
 	*obj = qp_sol->obj;
 	}
+
+
+
+void DENSE_QP_SOL_SET_V(REAL *v, struct DENSE_QP_SOL *qp_sol)
+	{
+	int nv = qp_sol->dim->nv;
+	PACK_VEC(nv, v, 1, qp_sol->v, 0);
+	}

--- a/examples/python/example_dense_qp_getting_started.py
+++ b/examples/python/example_dense_qp_getting_started.py
@@ -54,6 +54,7 @@ travis_run = os.getenv('TRAVIS_RUN')
 
 # define flags
 codegen_data = 1; # export qp data in the file dense_qp_data.c for use from C examples
+warm_start = 0; # set to 1 to warm-start the primal variable
 
 
 # dim
@@ -124,6 +125,10 @@ arg.set('tol_eq', 1e-5)
 arg.set('tol_ineq', 1e-5)
 arg.set('tol_comp', 1e-5)
 arg.set('reg_prim', 1e-12)
+
+# if warm_start=1, then the primal variable is initialized from qp_sol
+arg.set('warm_start', warm_start)
+qp_sol.set('v', np.array([0.30769244, -0.6923054, 1.38461296]))
 
 # codegen
 if codegen_data:

--- a/include/hpipm_d_dense_qp_sol.h
+++ b/include/hpipm_d_dense_qp_sol.h
@@ -95,6 +95,8 @@ void d_dense_qp_sol_get_valid_obj(struct d_dense_qp_sol *sol, int *valid_obj);
 //
 void d_dense_qp_sol_get_obj(struct d_dense_qp_sol *sol, double *obj);
 
+//
+void d_dense_qp_sol_set_v(double *v, struct d_dense_qp_sol *sol);
 
 
 #ifdef __cplusplus

--- a/include/hpipm_s_dense_qp_sol.h
+++ b/include/hpipm_s_dense_qp_sol.h
@@ -95,6 +95,8 @@ void s_dense_qp_sol_get_valid_obj(struct s_dense_qp_sol *sol, int *valid_obj);
 //
 void s_dense_qp_sol_get_obj(struct s_dense_qp_sol *sol, float *obj);
 
+//
+void s_dense_qp_sol_set_v(float *v, struct s_dense_qp_sol *sol);
 
 
 #ifdef __cplusplus

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_sol.py
@@ -112,6 +112,14 @@ class hpipm_dense_qp_sol:
 
 		return var
 
+	def set(self, field, value):
+		if((field=='v')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_dense_qp_sol_set_v(tmp, self.qp_sol_struct)
+		else:
+			raise NameError('hpipm_dense_qp_sol.set: wrong field')
+		return
 
 	def print_C_struct(self):
 		self.__hpipm.d_dense_qp_sol_print(self.dim.dim_struct, self.qp_sol_struct)

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_dense_qp_solver_arg.py
@@ -83,7 +83,7 @@ class hpipm_dense_qp_solver_arg:
 			tmp_in = np.zeros((1,1))
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_double))
-		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step')):
+		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step') | (field=='warm_start')):
 			tmp_in = np.zeros((1,1), dtype=int)
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_int))


### PR DESCRIPTION
This is small PR to expose the option of warm-starting the primal variables in the dense QP Python interface. This is feature supported by solvers in the [qpsolvers](https://github.com/qpsolvers/qpsolvers) project, so I wanted to add it here to facilitate the addition of HPIPM to qpsolvers.

Let me know what you think.