### PR TITLE
add x_ocp_qp_get_H

### DIFF
--- a/include/hpipm_d_ocp_qp.h
+++ b/include/hpipm_d_ocp_qp.h
@@ -219,6 +219,8 @@ void d_ocp_qp_get_S(int stage, struct d_ocp_qp *qp, double *mat);
 //
 void d_ocp_qp_get_R(int stage, struct d_ocp_qp *qp, double *mat);
 //
+void d_ocp_qp_get_H(int stage, struct d_ocp_qp *qp, double *mat);
+//
 void d_ocp_qp_get_q(int stage, struct d_ocp_qp *qp, double *vec);
 //
 void d_ocp_qp_get_r(int stage, struct d_ocp_qp *qp, double *vec);

--- a/include/hpipm_s_ocp_qp.h
+++ b/include/hpipm_s_ocp_qp.h
@@ -219,6 +219,8 @@ void s_ocp_qp_get_S(int stage, struct s_ocp_qp *qp, float *mat);
 //
 void s_ocp_qp_get_R(int stage, struct s_ocp_qp *qp, float *mat);
 //
+void s_ocp_qp_get_H(int stage, struct s_ocp_qp *qp, float *mat);
+//
 void s_ocp_qp_get_q(int stage, struct s_ocp_qp *qp, float *vec);
 //
 void s_ocp_qp_get_r(int stage, struct s_ocp_qp *qp, float *vec);

--- a/ocp_qp/d_ocp_qp.c
+++ b/ocp_qp/d_ocp_qp.c
@@ -146,6 +146,7 @@
 #define OCP_QP_GET_Q d_ocp_qp_get_Q
 #define OCP_QP_GET_S d_ocp_qp_get_S
 #define OCP_QP_GET_R d_ocp_qp_get_R
+#define OCP_QP_GET_H d_ocp_qp_get_H
 #define OCP_QP_GET_QVEC d_ocp_qp_get_q
 #define OCP_QP_GET_RVEC d_ocp_qp_get_r
 #define OCP_QP_GET_LBX d_ocp_qp_get_lbx

--- a/ocp_qp/s_ocp_qp.c
+++ b/ocp_qp/s_ocp_qp.c
@@ -146,6 +146,7 @@
 #define OCP_QP_GET_Q s_ocp_qp_get_Q
 #define OCP_QP_GET_S s_ocp_qp_get_S
 #define OCP_QP_GET_R s_ocp_qp_get_R
+#define OCP_QP_GET_H s_ocp_qp_get_H
 #define OCP_QP_GET_QVEC s_ocp_qp_get_q
 #define OCP_QP_GET_RVEC s_ocp_qp_get_r
 #define OCP_QP_GET_LBX s_ocp_qp_get_lbx

--- a/ocp_qp/x_ocp_qp.c
+++ b/ocp_qp/x_ocp_qp.c
@@ -1905,6 +1905,17 @@ void OCP_QP_GET_R(int stage, struct OCP_QP *qp, REAL *R)
 	}
 
 
+void OCP_QP_GET_H(int stage, struct OCP_QP *qp, REAL *H)
+	{
+	// extract dim
+	int *nx = qp->dim->nx;
+	int *nu = qp->dim->nu;
+
+	CVT_STRMAT2MAT(nu[stage]+nx[stage], nu[stage]+nx[stage], qp->RSQrq+stage, 0, 0, H, nu[stage]+nx[stage]);
+
+	return;
+	}
+
 
 void OCP_QP_GET_QVEC(int stage, struct OCP_QP *qp, REAL *q)
 	{


### PR DESCRIPTION
This will enable to use the HPIPM interface in the acados interface instead of doing something like this:
https://github.com/FreyJo/acados/blob/4adf2a86fc49db1fbd3bb23cc0629d774b984958/interfaces/acados_matlab_octave/ocp_get.c#L387