### PR TITLE
warm_start in ocp_qp and ocp_qcqp Python interfaces

### DIFF
--- a/examples/python/example_qcqp_getting_started.py
+++ b/examples/python/example_qcqp_getting_started.py
@@ -56,6 +56,7 @@ travis_run = os.getenv('TRAVIS_RUN')
 
 # define flags
 codegen_data = 1; # export qp data in the file ocp_qcqp_data.c for use from C examples
+warm_start = 0 # set to 1 to warm-start the primal variable
 
 
 
@@ -139,6 +140,16 @@ arg.set('tol_eq', 1e-5)
 arg.set('tol_ineq', 1e-5)
 arg.set('tol_comp', 1e-5)
 arg.set('reg_prim', 1e-12)
+
+# if warm_start=1, then the primal variable is initialized from qp_sol
+arg.set('warm_start', warm_start)
+if warm_start:
+	x_guess  = np.array([[1., 1.], [ 2., -1.04201383], [ 0.95798617, -0.89413254], [ 0.06385362, -0.36646102], [-0.3026074, 0.00481863], [-0.29778877, -0.10640653]])
+	u_guess  = np.array([[-2.04201383], [0.14788129], [0.52767152], [0.37127965], [-0.11122516]])
+	for i in range(N+1):
+		qp_sol.set('x', i, x_guess[i])
+	for i in range(N):
+		qp_sol.set('u', i, u_guess[i])
 
 # codegen
 if codegen_data:

--- a/examples/python/example_qp_getting_started.py
+++ b/examples/python/example_qp_getting_started.py
@@ -56,6 +56,7 @@ travis_run = os.getenv('TRAVIS_RUN')
 # define flags
 codegen_data = 0 # export qp data in the file ocp_qp_data.c for use from C examples
 reduce_eq_dof = 0 # eliminates e.g. equality constraint on x0
+warm_start = 0 # set to 1 to warm-start the primal variable
 
 if reduce_eq_dof:
 	codegen_data = 0 # not supported yet
@@ -178,6 +179,16 @@ arg.set('reg_prim', 1e-12)
 
 if reduce_eq_dof:
 	arg.set('reduce_eq_dof', 1)
+
+# if warm_start=1, then the primal variable is initialized from qp_sol
+arg.set('warm_start', warm_start)
+if warm_start:
+	x_guess  = np.array([[1.0, 1.0],[2., -1.025], [ 0.975, -0.85 ], [ 0.125, -0.275], [-0.15, 0.15], [0.0, 0.0]])
+	u_guess  = np.array([[-2.025], [0.175], [0.575], [0.425], [-0.15]])
+	for i in range(N+1):
+		qp_sol.set('x', i, x_guess[i])
+	for i in range(N):
+		qp_sol.set('u', i, u_guess[i])
 
 # codegen
 if codegen_data:

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_sol.py
@@ -118,6 +118,26 @@ class hpipm_ocp_qcqp_sol:
 				self.__hpipm.d_ocp_qcqp_sol_get_x(i, self.qp_sol_struct, tmp_ptr)
 		return x
 
+	def set(self, field, stage, value):
+		if((field=='x')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qcqp_sol_set_x(stage, tmp, self.qp_sol_struct)
+		elif((field=='u')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qcqp_sol_set_u(stage, tmp, self.qp_sol_struct)
+		elif((field=='sl')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qcqp_sol_set_sl(stage, tmp, self.qp_sol_struct)
+		elif((field=='su')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qcqp_sol_set_su(stage, tmp, self.qp_sol_struct)
+		else:
+			raise NameError('hpipm_ocp_qcqp_sol.set: wrong field')
+		return
 
 	def print_C_struct(self):
 		self.__hpipm.d_ocp_qcqp_sol_print(self.dim.dim_struct, self.qp_sol_struct)

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_solver_arg.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qcqp_solver_arg.py
@@ -85,7 +85,7 @@ class hpipm_ocp_qcqp_solver_arg:
 			tmp_in = np.zeros((1,1))
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_double))
-		elif(field=='iter_max'):
+		elif((field=='iter_max') | (field=='warm_start')):
 			tmp_in = np.zeros((1,1), dtype=int)
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_int))

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
@@ -109,6 +109,27 @@ class hpipm_ocp_qp_sol:
 
 		return var if len(var) > 1 else var[0]
 
+	def set(self, field, stage, value):
+		if((field=='x')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qp_sol_set_x(stage, tmp, self.qp_sol_struct)
+		elif((field=='u')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qp_sol_set_u(stage, tmp, self.qp_sol_struct)
+		elif((field=='sl')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qp_sol_set_sl(stage, tmp, self.qp_sol_struct)
+		elif((field=='su')):
+			value = np.ascontiguousarray(value, dtype=np.float64)
+			tmp = cast(value.ctypes.data, POINTER(c_double))
+			self.__hpipm.d_ocp_qp_sol_set_su(stage, tmp, self.qp_sol_struct)
+		else:
+			raise NameError('hpipm_ocp_qp_sol.set: wrong field')
+		return
+
 	def print_C_struct(self):
 		self.__hpipm.d_ocp_qp_sol_print(self.dim.dim_struct, self.qp_sol_struct)
 		return

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver_arg.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver_arg.py
@@ -84,7 +84,7 @@ class hpipm_ocp_qp_solver_arg:
 			tmp_in = np.zeros((1,1))
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_double))
-		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step')):
+		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step') | (field=='warm_start')):
 			tmp_in = np.zeros((1,1), dtype=int)
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_int))

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver_arg2.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver_arg2.py
@@ -84,7 +84,7 @@ class hpipm_ocp_qp_solver_arg2:
 			tmp_in = np.zeros((1,1))
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_double))
-		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step') | (field=='reduce_eq_dof')):
+		elif((field=='iter_max') | (field=='pred_corr') | (field=='split_step') | (field=='reduce_eq_dof') | (field=='warm_start')):
 			tmp_in = np.zeros((1,1), dtype=int)
 			tmp_in[0][0] = value
 			tmp = cast(tmp_in.ctypes.data, POINTER(c_int))


### PR DESCRIPTION
Inspired by https://github.com/giaf/hpipm/pull/140, this PR adds the warm_start option in the ocp_qp and ocp_qcqp Python interfaces.

In https://github.com/th1991-01/hpipm/commit/5f23ba3756fe212ee126009b585cbc7c0447826a, I define `def set(self, field, stage, value)` in Python by imitating `void d_ocp_qp_sol_set(char *field, int stage, double *vec, struct d_ocp_qp_sol *qp_sol)`  in C.
If another function definition is better, I will change it.