### PR TITLE
Bugfix/missing dim arg in c interface

### DIFF
--- a/interfaces/c/x_ocp_qp_solver.c
+++ b/interfaces/c/x_ocp_qp_solver.c
@@ -52,7 +52,7 @@ hpipm_size_t OCP_QP_SOLVER_ARG_MEMSIZE(struct d_ocp_qp_dim *ocp_dim)
 	hpipm_size_t size = 0;
 
 	size += sizeof(struct OCP_QP_IPM_ARG);
-	size += 1*OCP_QP_IPM_ARG_MEMSIZE(ocp_dim); // XXX dim is not used in there
+	size += 1*OCP_QP_IPM_ARG_MEMSIZE(ocp_dim);
 
 	size += sizeof(struct OCP_QP_REDUCE_EQ_DOF_ARG);
 	size += 1*OCP_QP_REDUCE_EQ_DOF_ARG_MEMSIZE();
@@ -95,7 +95,7 @@ void OCP_QP_SOLVER_ARG_CREATE(struct OCP_QP_DIM *ocp_dim, struct OCP_QP_SOLVER_A
 	char *c_ptr = (char *) s_ptr;
 
 	//
-	OCP_QP_IPM_ARG_CREATE(ocp_dim, arg->ipm_arg, c_ptr); // XXX dim is not used in there
+	OCP_QP_IPM_ARG_CREATE(ocp_dim, arg->ipm_arg, c_ptr);
 	c_ptr += arg->ipm_arg->memsize;
 	//
 	OCP_QP_REDUCE_EQ_DOF_ARG_CREATE(arg->red_arg, c_ptr);

--- a/interfaces/c/x_ocp_qp_solver.c
+++ b/interfaces/c/x_ocp_qp_solver.c
@@ -52,7 +52,7 @@ hpipm_size_t OCP_QP_SOLVER_ARG_MEMSIZE(struct d_ocp_qp_dim *ocp_dim)
 	hpipm_size_t size = 0;
 
 	size += sizeof(struct OCP_QP_IPM_ARG);
-	size += 1*OCP_QP_IPM_ARG_MEMSIZE(NULL); // XXX dim is not used in there
+	size += 1*OCP_QP_IPM_ARG_MEMSIZE(ocp_dim); // XXX dim is not used in there
 
 	size += sizeof(struct OCP_QP_REDUCE_EQ_DOF_ARG);
 	size += 1*OCP_QP_REDUCE_EQ_DOF_ARG_MEMSIZE();
@@ -95,7 +95,7 @@ void OCP_QP_SOLVER_ARG_CREATE(struct OCP_QP_DIM *ocp_dim, struct OCP_QP_SOLVER_A
 	char *c_ptr = (char *) s_ptr;
 
 	//
-	OCP_QP_IPM_ARG_CREATE(NULL, arg->ipm_arg, c_ptr); // XXX dim is not used in there
+	OCP_QP_IPM_ARG_CREATE(ocp_dim, arg->ipm_arg, c_ptr); // XXX dim is not used in there
 	c_ptr += arg->ipm_arg->memsize;
 	//
 	OCP_QP_REDUCE_EQ_DOF_ARG_CREATE(arg->red_arg, c_ptr);
@@ -374,7 +374,7 @@ void OCP_QP_SOLVER_SET(char *field, void *value, struct OCP_QP_SOLVER_WS *ws)
 #ifdef EXT_DEP
 		printf("error: OCP_QP_SOLVER_ARG_SET: wrong field %s\n", field);
 #endif
-		exit(1);	
+		exit(1);
 		}
 	return;
 	}
@@ -558,5 +558,3 @@ void OCP_QP_SOLVER_SENS_FRW(struct OCP_QP *qp, struct OCP_QP_SEED *qp_seed, stru
 		}
 	return;
 	}
-
-


### PR DESCRIPTION
@giaf  It appears that the comment `XXX dim is not used in there` isn't valid anymore since [last week](https://github.com/giaf/hpipm/blame/37b78acc337982e4dd80eccb2343a6d6afedac59/ocp_qp/x_ocp_qp_ipm.c#L48). The Python example `example_qp_getting_started.py` was crashing if I set [`reduce_qp_dof = 1`](https://github.com/giaf/hpipm/blob/37b78acc337982e4dd80eccb2343a6d6afedac59/examples/python/example_qp_getting_started.py#L58). With the changes below the Python script doesn't crash for me.